### PR TITLE
add default login and password to installation-guide page

### DIFF
--- a/docs/user-guide_install.md
+++ b/docs/user-guide_install.md
@@ -56,7 +56,10 @@ Remove the SD card from the PC and insert it into the Raspberry Pi to prepare to
 
 ## First boot on DietPi
 
-Insert the SD card into your Raspberry Pi and start it. A few seconds later, you can connect following the instructions on the screen, or connecting via network (through SSH). 
+Insert the SD card into your Raspberry Pi and start it. A few seconds later, you can connect following the instructions on the screen, or connecting via network (through SSH).
+
+- login: **root**
+- password: **dietpi**
 
 ### Headless install
 


### PR DESCRIPTION
Looks like there's no default credentials on [installation guide page](https://dietpi.com/docs/user-guide_install/), though DietPi requires them at first login. These ones I found at https://dietpi.com/phpbb/viewtopic.php?t=9 , and they matched with required, maybe it would be useful to have this at main installation page too.