### PR TITLE
Markdown-link | Allow question marks in headers

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -7,5 +7,8 @@
   "MD025": {
     "front_matter_title": ""
   },
+  "MD026": {
+    "punctuation": ".,;:!"
+  },
   "MD033": false
 }


### PR DESCRIPTION
To liberate this rule: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md026---trailing-punctuation-in-header
The rule could be seen as good practice in general, e.g. not asking questions in headers but giving answers, like:

Instead of "What is DietPi?"
"About DietPi" or simpler "Introduction".

Instead of "What is supported?"
"Supported hardware" or "Supported devices" or "Supported SBCs" like we call the other page.

But actually I'm fine with questions, especially "What is DietPi?" simply matches what I read all the time, e.g. on Twitter when someone mentions us, so I like that question being the first thing you see when accessing the wiki.