### PR TITLE
Changes on install & tools

### DIFF
--- a/docs/dietpi_tools.md
+++ b/docs/dietpi_tools.md
@@ -2,16 +2,46 @@
 
 ## DietPi-Launcher
 
+**dietpi-software** will be automatically ran on the first login. It could be accessed at any time running next next from the command line:
+
+``` bash
+dietpi-launcher
+```
+
 It is the main program to run whenever you have a DietPi OS. It provides a quick access to all the main DietPi programs.
 
 ![dietpi-launcher](assets/images/dietpi-launcher.jpg)
 
 ## DietPi-Software
 
-DietPi-Software will be automatically displayed on the first login. It is one of the core tools, enabling the installation of one or multiple software items, either:
+**dietpi-software** will be automatically displayed on the first login. It could be accessed at any time running next next from the command line:
+
+``` bash
+dietpi-software
+```
+
+![dietpi-software](assets/images/dietpi-software.jpg)
+
+It is one of the core tools, enabling you to install or uninstall one or more 
+[**DietPi optimised software**](../software/) titles.
 
 === "Software Optimised"
-    This contains a long list of optimised software. You either browse the list by selecting **Software optimised** or used the option **Search**.
+
+    - Begin by selecting **Software Optimized** in the main menu list and hit Enter.    
+
+    - Scroll through the list of available software - for more details check [DietPi Optimised Software](../user-optimised_software). 
+    
+    The list of optimised software is long. You either browse the list or use the option **Search**.
+
+    - To install software on your DietPi, select it in the list and press the **space bar** to add it to the installation list. If you change your mind, hit space again to remove it.
+
+    - Once you’ve selected the software you wish to install, press the tab key on your keyboard to switch to the confirmation options at the bottom. Select **OK**, then hit enter on your keyboard to confirm.
+
+    - To begin installing your software, select **Install** from the main menu list, then hit the Enter key. DietPi will ask you to confirm your choice(s). Select **OK**, then hit enter to begin the installation.
+
+    The software you selected will begin to install at this point. Once the process is completed, you may be asked to restart your device. Press **OK** to confirm.
+
+    ![dietpi-software](assets/images/dietpi-software-optimised.jpg)
 
 === "Software Additional"
     This section provides:
@@ -19,125 +49,123 @@ DietPi-Software will be automatically displayed on the first login. It is one of
     - software packages that are often used and installed via `apt install <package>`, without additional optimisation from DietPi team.
     - _or_ packages not directly required, but pulled as a dependency, like: build tools, libraries or runtime systems.
 
-![dietpi-software](assets/images/dietpi-software.jpg)
+You can return to the **DietPi-Software** tool to make further changes at any time by typing `dietpi-software` at the terminal, or enter `dietpi-launcher` and select **DietPi-Software** tool.
 
-### Software Optimised
 
-Select DietPi optimised software to install.
+**Install** 
 
-![dietpi-software](assets/images/dietpi-software-optimised.jpg)
+Install selected software item(s), and these could come both from **optimised software** list or **additional software** items.
 
-### Install / Uninstall
+**Uninstall**
 
-Use this option to:
-
-- install selected software items (either **optimised software** or **additional software** items)
-- or select and then remove installed software from your operating system.
+Select one or more software items which you would like to be removed from your DietPi installation.
 
 ## Configuration
 
-### DietPi-Config
+`dietpi-config`{: #DietPi-Config }
 
-Configure various system settings, from display / audio / network to _auto start_ options.  
+:    Configure various system settings, from display / audio / network to _auto start_ options.  
 
-![dietpi-config](assets/images/dietpi-config.jpg)
+    ![dietpi-config](assets/images/dietpi-config.jpg)
 
-### DietPi-Drive_Manager
+`dietpi-drive_manager` {: #dietpi-drive_manager }
 
-Feature-rich drive management utility.
+:    Feature-rich drive management utility.
 
-![dietpi-drive_manager](assets/images/dietpi-drive-manager.jpg)
+    ![dietpi-drive_manager](assets/images/dietpi-drive-manager.jpg)
 
-### DietPi-AutoStart
+`dietpi-autostart` {: #dietpi-autostart }
 
-Defines software packages to start when the DietPi OS boots up. Example, boot into the desktop with Kodi running.
+:    Defines software packages to start when the DietPi OS boots up. Example, boot into the desktop with Kodi running.
 
-![dietpi-autostart](assets/images/dietpi-autostart.jpg)
+    ![dietpi-autostart](assets/images/dietpi-autostart.jpg)
 
-### DietPi-Services
+`dietpi-services` {: #dietpi-services }
 
-Provides service control, priority level tweaks and status print.
+:    Provides service control, priority level tweaks and status print.
 
-![dietpi-services](assets/images/dietpi-services.jpg)
+    ![dietpi-services](assets/images/dietpi-services.jpg)
 
-### DietPi-LED_control
+`dietpi-led_control` {: #dietpi-led_control }
 
-![dietpi-led_control](assets/images/dietpi-ledcontrol.jpg)
+:    ![dietpi-led_control](assets/images/dietpi-ledcontrol.jpg)
 
-### DietPi-Cron
+`dietpi-cron` {: #dietpi-cron }
 
-Modify the start times of specific cron job groups.
+:    Modify the start times of specific cron job groups.
 
-![dietpi-cron](assets/images/dietpi-cron.jpg)
+    ![dietpi-cron](assets/images/dietpi-cron.jpg)
 
-### DietPi-JustBoom
+`dietpi-justboom` {: #dietpi-justboom }
 
-Change the audio settings
+:    Change the audio settings
 
-![dietpi-justBoom](assets/images/dietpi-justboom.jpg)
+    ![dietpi-justBoom](assets/images/dietpi-justboom.jpg)
 
-## DietPi-Update / DietPi-Backup / DietPi-Sync
+`dietpi-sync`  {: #dietpi-sync }
 
-### DietPi-Update
+:    Sync or duplicate a directory to another
 
-Update DietPi OS version to the latest version available.
+    ![dietpi-sync](assets/images/dietpi-sync.jpg)
 
-### DietPi-Backup
+## Update & Backup 
 
-Fully backup DietPi setup or restore from an already available DietPi backup.
+`dietpi-update` {: #dietpi-update }
 
-### DietPi-Sync
+:    Update DietPi OS version to the latest version available.
 
-Sync or duplicate a directory to another
+`dietpi-backup` {: #dietpi-backup }
 
-![dietpi-sync](assets/images/dietpi-sync.jpg)
+:    Fully backups DietPi setup. It also includes the restore capability from an already made DietPi backup.
 
-## Misc
+## Let's encrypt SSL & NordVPN support
 
-### DietPi CPU Info
+`dietpi-letsencrypt` {: #dietpi-letsencrypt }
 
-Displays CPU temperature, processor frequency, throttle level etc.
+:    Access the frontend for the `Let's Encrypt` integration.
 
-![dietpi-cpuinfo](assets/images/dietpi-cpuinfo.jpg)
+    ![dietpi-letsencrypt](assets/images/dietpi-letsencrypt.jpg)
 
-### DietPi-LetsEncrypt
+`dietpi-nordvpn` {: #dietpi-nordvpn }
 
-Access the frontend for the `Let's Encrypt` integration.
+:    ![dietpi-nordvpn](assets/images/dietpi-nordvpn.jpg)
 
-![dietpi-letsencrypt](assets/images/dietpi-letsencrypt.jpg)
+## Miscellaneous
 
-### DietPi-NordVPN
+`dietpi-cpuinfo` {: #dietpi-cpuinfo }
 
-![dietpi-nordvpn](assets/images/dietpi-nordvpn.jpg)
+:    Displays CPU temperature, processor frequency, throttle level etc.
 
-### DietPi-Survey
+    ![dietpi-cpuinfo](assets/images/dietpi-cpuinfo.jpg)
 
-![dietpi-survey](assets/images/dietpi-survey.jpg)
+`dietpi-survey` {: #dietpi-survey }
 
-### DietPi-Bugreport
+:    ![dietpi-survey](assets/images/dietpi-survey.jpg)
 
-![dietpi-bugreport](assets/images/dietpi-bugreport.jpg)
+`dietpi-bugreport` {: #dietpi-bugreport }
 
-### DietPi-Morsecode
+:    ![dietpi-bugreport](assets/images/dietpi-bugreport.jpg)
 
-Convert a text file into morse code.
+`dietpi-morsecode` {: #dietpi-morsecode }
+
+:    It converts a text file into morse code.
 
 ## Maintenance
 
-### DietPi-Explorer
+`dietpi-explorer` {: #dietpi-explorer }
 
-Lightweight file manager and explorer
+:    Lightweight file manager and explorer
 
-![dietpi-explorer](assets/images/dietpi-explorer.jpg)
+    ![dietpi-explorer](assets/images/dietpi-explorer.jpg)
 
-### DietPi-Cleaner
+`dietpi-cleaner` {: #dietpi-cleaner }
 
-Clean up not necessary files from the operating system and free up valuable disk space.
+:    Clean up not necessary files from the operating system and free up valuable disk space.
 
-![dietpi-cleaner](assets/images/dietpi-cleaner.jpg)
+    ![dietpi-cleaner](assets/images/dietpi-cleaner.jpg)
 
-### DietPi-LogClear
+`dietpi-logclear` {: #dietpi-logclear }
 
-Clear log files in /var/log/.
+:    Clear log files in /var/log/.
 
-![dietpi-logclear](assets/images/dietpi-logclear.jpg)
+    ![dietpi-logclear](assets/images/dietpi-logclear.jpg)

--- a/docs/dietpi_tools.md
+++ b/docs/dietpi_tools.md
@@ -2,28 +2,26 @@
 
 ## DietPi-Launcher
 
-**dietpi-software** will be automatically ran on the first login. It could be accessed at any time running next next from the command line:
+It provides an easy access to all DietPi OS tools, and it could be accessed by running next command:
 
 ``` bash
 dietpi-launcher
 ```
 
-It is the main program to run whenever you have a DietPi OS. It provides a quick access to all the main DietPi programs.
-
 ![dietpi-launcher](assets/images/dietpi-launcher.jpg)
 
 ## DietPi-Software
 
-**dietpi-software** will be automatically displayed on the first login. It could be accessed at any time running next next from the command line:
+**dietpi-software** will be automatically displayed on the first login after the installation. It could be accessed at any time running next command:
 
 ``` bash
 dietpi-software
 ```
 
-![dietpi-software](assets/images/dietpi-software.jpg)
-
 It is one of the core tools, enabling you to install or uninstall one or more 
 [**DietPi optimised software**](../software/) titles.
+
+![dietpi-software](assets/images/dietpi-software.jpg)
 
 === "Software Optimised"
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,6 @@
 # DietPi Updates
 
-## To be released in October 2020 (version 6.33)
+## October 2020 (version 6.33)
 
 ### Highlights
 
@@ -8,6 +8,24 @@
 
     ![DietPi-Software Bazarr](assets/images/dietpi-software_bazarr.jpg)
     For more details on installation and configuration open [DietPi Optimised Software - Bazarr](../software/bittorrent#bazarr) page.
+
+:    Companion application to Sonarr and Radarr, which manages and downloads subtitles based on your requirements, now available for install. Open [Bazarr](../software/bittorrent#bazarr) page in [Optimised software](../software/).
+    Many thanks to @DiogoAbu for doing this suggestion [Issue #2045](https://github.com/MichaIng/DietPi/issues/2045)
+
+- **Docker logging available in RAM/journald** 
+    This feature is now available to newly fresh Docker installs or reinstalls. Logs are now done with limited verbosity to systemd-journald (RAM). They could be accessible running next command: 
+    
+``` bash
+journalctl -u docker -u containerd
+``` 
+:    This change brings the advantage that reduces the disk writes, as well as make them accessible to system journal (external to containerized environment). To fully benefit from this improvment, Docker can be reinstalled using next command:
+
+``` bash
+dietpi-software reinstall 162
+``` 
+
+:    Many thanks to @SaturnusDJ for doing this suggestion: [Issue #2388](https://github.com/MichaIng/DietPi/issues/2388)
+
 
 ### Improvements
 
@@ -18,9 +36,6 @@
 
     If the user (+group) is created by an external package or installer, the original primary group is kept as supplementary group to not possibly break access permissions to pre-created directories and files.
     Currently, only exception from these changes is _Deluge_ - we don't want to run the separate web UI service with `dietpi` group permissions. In case of _Tautulli_, the `dietpi` group permissions are remove, since _Tautulli_ does not require it.
-
-- **DietPi-Software** :octicons-heart-16: **Bazarr** :octicons-arrow-right-16: Companion application to Sonarr and Radarr, which manages and downloads subtitles based on your requirements, now available for install. Open [Bazarr](../software/bittorrent#bazarr) page in [Optimised software](../software/).
- Many thanks to @DiogoAbu for doing this suggestion [Issue #2045](https://github.com/MichaIng/DietPi/issues/2045)
 
 - **DietPi-Software**  :octicons-commit-24:  **phpBB** :octicons-arrow-right-16: New phpBB installations will be done using version 3.3.1. Existing instances won't be touched, as updates need to be done manually through the internal update mechanism, which includes the mandatory database migration.
 
@@ -42,19 +57,19 @@
 
     The webserver configurations have been added to harden access permissions.
 
-- **DietPi-Software**  :octicons-commit-24: **Docker** :octicons-arrow-right-16: On fresh installs or reinstalls, logs are now done with limited verbosity to systemd-journald (RAM), accessible via `"journalctl -u docker -u containerd"` to reduce disk writes.
-
-    Docker can be reinstalled via `"dietpi-software reinstall 162"`.
-
-    Many thanks to @SaturnusDJ for doing this suggestion: [Issue #2388](https://github.com/MichaIng/DietPi/issues/2388)
-
 - **DietPi-Software**  :octicons-commit-24: **Mosquitto** :octicons-arrow-right-16: The official APT repository is now used where possible, which currently excludes ARMv8/arm64 and Raspbian/Debian Bullseye. This change is applied via reinstall during DietPi update.
 
     Many thanks to @marcobrianza for doing this suggestion: [Issue #3042](https://github.com/MichaIng/DietPi/issues/3042)
 
-- **DietPi-Software**  :octicons-commit-24: **Cuberite** :octicons-arrow-right-16: A wrong directory name based on a typo has been fixed.
+- **DietPi-Software** :octicons-commit-24: **Cuberite** :octicons-arrow-right-16: A wrong directory name based on a typo has been fixed.
 
     A reinstall updates Cuberite and moves its install directory to `/mnt/dietpi_userdata/cuberite` as intended. This is applied via DietPi update but a backup is created to cover issues due to potential structural changes, especially for older instances installed at /etc/cuberite.
+
+### Documentation improvements
+
+- **Installation guide** :octicons-arrow-right-16: It has been fully changed & simplified. There is a single page with more tabs. The page highlights different steps used for different platforms, while it keeps the common structure. Many thanks to @StephanStS for doing these updates.
+
+- **Writing rules** :octicons-arrow-right-16: The documentation has evolved. It starts to have a file naming convention, more url updated and so on. Many thanks to @StephanStS for doing these updates.   
 
 ### APT Changes
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -45,9 +45,13 @@ dietpi-software reinstall 162
 
     To apply these changes, OctoPrint is reinstalled with DietPi v6.33, which includes the Python 3 migration (see v6.32 changelog) on Buster and Bullseye systems. This implies that the CLI (`"octoprint"` command) needs to be executed as user `"octoprint"` to invoke the correct configuration.
 
-    A bash shell alias solves this automatically for all users with sudo permissions, but if you use a custom shell, the CLI needs to be called like: `"sudo -u octoprint octoprint <command>"`.
+    A bash shell alias solves this automatically for all users with sudo permissions, but if you use a custom shell, the CLI needs to be called like: 
+    
+``` bash
+sudo -u octoprint octoprint <command>
+```
 
-    Many thanks to @ModischFabrications for reporting an issue that is related to the fact that the service ran as root user before: [Issue #3315](https://github.com/MichaIng/DietPi/issues/3315)
+:    Many thanks to @ModischFabrications for reporting an issue that is related to the fact that the service ran as root user before: [Issue #3315](https://github.com/MichaIng/DietPi/issues/3315)
 
 - **DietPi-Software** :octicons-commit-24: **Tautulli** :octicons-arrow-right-16: Directories, user and service are renamed from `"plexpy"` to `"tautulli"`.
 
@@ -65,13 +69,17 @@ dietpi-software reinstall 162
 
     A reinstall updates Cuberite and moves its install directory to `/mnt/dietpi_userdata/cuberite` as intended. This is applied via DietPi update but a backup is created to cover issues due to potential structural changes, especially for older instances installed at /etc/cuberite.
 
+- **DietPi-Software** :octicons-commit-24: **Amiberry** :octicons-arrow-right-16: An update to Amiberry v3.3 is applied during DietPi v6.33 update.
+
+- **DietPi-Software** :octicons-commit-24: **LXDE** :octicons-arrow-right-16: By default, when double-clicking a desktop icon or executable file, it will be executed directly now, without being asked first what to do. This behaviour can be changed from within PCManFM file manager > "Edit" > "Preferences" > "General" > "Don't ask options to launch executable file".
+
 ### Documentation improvements
 
 - **Installation guide** :octicons-arrow-right-16: It has been fully changed & simplified. There is a single page with more tabs. The page highlights different steps used for different platforms, while it keeps the common structure. Many thanks to @StephanStS for doing these updates.
 
 - **Writing rules** :octicons-arrow-right-16: The documentation has evolved. It starts to have a file naming convention, more url updated and so on. Many thanks to @StephanStS for doing these updates.   
 
-### APT Changes
+### API Changes
 
 - **DietPi-Globals** :octicons-arrow-right-16: The G_FP_DIETPI_USERDATA variable has been removed. Variables cannot be used in every context, e.g. not in config files stored on GitHub or dietpi.com for download, its value "/mnt/dietpi_userdata" does not change and using the path literally allows slightly simplified and hardened coding.
 
@@ -93,9 +101,13 @@ dietpi-software reinstall 162
 
 - **DietPi-Config** :octicons-arrow-right-16: Resolved an issue where on devices with old Linux kernel versions (e.g. Sparky SBC with Linux 3.10.38) the Performance Options failed to open with a syntax error. Many thanks to @dsnyder0pc for reporting this issue: [Issue #3799](https://github.com/MichaIng/DietPi/issues/3799)
 
+-  **DietPi-Config** :octicons-arrow-right-16: Resolved an issue on RPi 2 where a wrong default SDRAM frequency was shown, which is 450 MHz instead of 400 MHz with current firmware.
+ 
 - **DietPi-Software**  :octicons-commit-24: **OpenTyrian** :octicons-arrow-right-16: The autostart option and run script have been fixed and slightly enhanced to lower RAM usage a bid.
 
 - **DietPi-Software** :octicons-commit-24: **Firefox Sync Server** :octicons-arrow-right-16: Resolved an issue where the build failed due to missing MySQL/MariaDB headers, newly required. Many thanks to @kinoushe for reporting this issue: [Issue #3744](https://github.com/MichaIng/DietPi/issues/3774)
+
+ - **DietPi-Software** :octicons-commit-24: **Firefox Sync Server** :octicons-arrow-right-16: Resolved another issue where the build failed due to transition of the whole project from Python to Rust. We now stay on a fixed commit and won't ship newer Firefox Sync Server versions until this transition has been fully completed, as the install process and requirements will constantly change. Many thanks again to @kinoushe for reporting this issue.
 
 - **DietPi-Software** :octicons-commit-24: **LXDE** :octicons-arrow-right-16: Resolved several issues due to conflicts between the RPi desktop LXDE packages with native LXDE.
 
@@ -110,6 +122,10 @@ dietpi-software reinstall 162
 - **DietPi-Software** :octicons-commit-24: **Kodi** :octicons-arrow-right-16: Resolved an issue on Odroid XU4 where install failed due to missing librockchip-mpp1 package which instead was aimed to be installed on Odroid N1 only.
 
 - **DietPi-Software** :octicons-commit-24: **TigerVNC+LXDE** :octicons-arrow-right-16: Resolved an issue where `lxappearance` start ("Customize Look and Feel") hangs within TigerVNC sessions.
+
+- **DietPi-Software** :octicons-commit-24: **Fail2Ban** :octicons-arrow-right-16: Resolved an issue where the service could have failed to start due to a missing variable declaration in our default config. Many thanks to @mafioso12dk for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=8147
+
+- **DietPi-Software** :octicons-commit-24: **DietPi-RAMlog** :octicons-arrow-right-16: Resolved an issue where /var/log content was not restored when reinstalling DietPi-RAMlog, e.g. when swiching logging mode from #1 to #2. This could have led to service start issues, when those rely on log files or directories being present. Many thanks to @djashdj for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=8163
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: <https://github.com/MichaIng/DietPi/pull/XXXX>
 

--- a/docs/user-guide_installation.md
+++ b/docs/user-guide_installation.md
@@ -5,24 +5,26 @@ title: How to install DietPi
 
 # How to install DietPi
 
-The installation of DietPi consists of several steps:
+The installation of DietPi consists of few steps:
 
-1. Provide an installation media (e.g. SD card for single board computer or USB stick for PC)
-2. Get the DietPi image (and put it on the installation media)
-3. Boot up the DietPi device and go through one time installation steps
+- Provide an installation media (e.g. SD card for single board computer or USB stick for PC)
+- Get the DietPi image (and put it on the installation media)
+- Boot up the DietPi device and go through one time installation steps
 
-Afterwards these steps you will be able to install additional software packages using an easy to use command line script ([`dietpi-software`](../dietpi_tools/#dietpi-software)).
+Following these steps you will be able to initially setup DietPi and install additional software packages you would like to use, using [dietpi-software](../dietpi_tools/#dietpi-software).
 
 Select the following tabs for the installation description of your target.
 
 === "Install on SBC"
 
     ## Introduction
+    
     Single board computers (SBCs) based on the well known Raspberry PI ARM based architecture gained more and more friends in the last years. The low cost in combination with the power and hardware flexibility makes these SBCs optimal for embedded systems, like e.g. home automation or cloud applications.
 
     ![raspberry-pi-1-model-b](assets/images/raspberry-pi-1b.jpg)
 
     ## Prerequisites
+
     To follow this tutorial, you will need the next hardware list:
 
     - A Raspberry Pi, Odroid or other SBC - open [the list of all supported SBC](../hardware-supported_sbc/)
@@ -44,7 +46,7 @@ Select the following tabs for the installation description of your target.
 
     Linux users will need to download and install `p7zip` (the terminal version of `7zip`).
 
-    ??? info "How do I extract DietPi image on Linux"
+    ??? hint "How do I extract DietPi image on Linux"
         On Debian and Ubuntu-based systems, open a terminal and type:
         ```
         sudo apt install p7zip
@@ -57,12 +59,14 @@ Select the following tabs for the installation description of your target.
 
         Replace **DietPi-Image.7z** with the correct name of your compressed DietPi file, example: **DietPi_RPi-ARMv6-Buster.7z**. This will extract the DietPi image file for you to use.
 
-    ## 2. Run balenaEtcher and flash the image
+    ## 2. Flash the DietPi image
 
-    Download and install [balenaEtcher](https://etcher.io/) - it flashes OS images to SD cards & USB drives, safely and easily on Windows, macOS, Linux.  
-    You may also use [Rufus](https://rufus.ie/) to flash the SD card. See ***Install on native PC (UEFI)*** for an example of the usage of Rufus.
+    At first, download and install [balenaEtcher](https://etcher.io/). This application flashes OS images to SD cards & USB drives, safely and easily on Windows, macOS, Linux.  
 
-    Start the program and make sure you have your SD card inserted into your computer. Locate and select the DietPi image.
+    !!! note ""
+        You may also use [Rufus](https://rufus.ie/) to flash the SD card. In the same page, click on **Install on native PC (UEFI)** tab to see an example of using Rufus.
+
+    Start balenaEtcher and make sure you have your SD card inserted into your computer. Locate and select the DietPi image.
 
     ![DietPi-Etcher-install-01](assets/images/DietPi-Etcher-install-01.jpg)
 
@@ -86,18 +90,17 @@ Select the following tabs for the installation description of your target.
         3.  In the same file `dietpi-wifi.txt`, set `aWIFI_KEY[0]` to the password of your WiFi network.
         4.  Save and close the files
 
+    ## 3. Prepare the first boot
 
-    ## 3. Prepare the first boot of your SBC
-
-    Remove the SD card from the PC and insert it into your device, preparing to boot for the first time.  
+    Remove the SD card from the PC and insert it into your SBC device, preparing to boot for the first time.  
     Power on the SBC to login and execute the first boot procedure.  
 
-    !!! info "Initial boot duration"
+    ???+ hint "Initial boot duration"
         Due to a resize of the SD card filesystem this initial boot takes a longer time than further system booting sequences. It may last up to a couple of minutes, depending on the SD card size, SD card speed and system speed.
 
 === "Install on native PC (UEFI)"
 
-    ## Introduction
+    <font size="+2">Introduction</font>
 
     The Native PC images are great for those occasions where SBC performance is just not enough. One example could be [Intel NUC Kit](https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits.html?page=2). It is a small, versatile, upgradable, and affordable desktop PC with the same basic feature set as that of a much larger machine.
 
@@ -105,7 +108,8 @@ Select the following tabs for the installation description of your target.
 
     It could be also a great way to make use of an old computer that’s not capable of running the latest version of Windows or macOS.
 
-    ## Prerequisites
+    <font size="+2">Prerequisites</font>
+
     You would need the next:
 
     - one **working PC with internet access**, helping to flash the boot media
@@ -113,7 +117,7 @@ Select the following tabs for the installation description of your target.
     - **target PC** to be installed
 
 
-    ## 1. Download and extract the DietPi disk image
+    <font size="+2">1. Download and extract the DietPi disk image</font>
 
     Download the **DietPi installer image** from [dietpi.com](https://dietpi.com/#download) and
     unzip the downloaded file to a local folder. It is a _7z_ archive format so you will need to install either [7zip for Windows](https://www.7-zip.org/) or other alternative tools.
@@ -125,7 +129,7 @@ Select the following tabs for the installation description of your target.
     !!! warning "Be careful if you run alternative applications!"
         While [Balena Etcher](https://www.balena.io/etcher/) is recommended for installing DietPi on SBCs, it does not provide good results for UEFI images. The same also with win32diskimager, which does not work as an alternative.
 
-    ## 2. Flash image to USB drive
+    <font size="+2">2. Flash image to USB drive</font>
 
     Start [Rufus](https://rufus.ie/) application and make sure you have your USB drive inserted into your computer. Follow the next steps:
 
@@ -140,10 +144,9 @@ Select the following tabs for the installation description of your target.
     !!! warning "All data on the USB medium and on the target PCs harddisk will be erased!"
         Before starting the installation first make a backup of the data available on the target PC and USB drive if you need it later again!
 
-
     ![dietpi-rufus-uefi](assets/images/dietpi-rufus-uefi.jpg)
 
-    ## 3. Boot the target PC and install the image on the local disk
+    <font size="+2">3. Boot the target PC and install the image on the local disk</font>
 
     Boot the **target PC** from USB image and install the image on the local disk / harddisk. Put the USB stick into the target PC and boot from this USB stick  
 
@@ -183,7 +186,7 @@ Select the following tabs for the installation description of your target.
 
 === "Install in VirtualBox"
 
-    ## Introduction
+    <font size="+2">Introduction</font>
 
     Virtual machine images are great for those occasions where you want to set up a DietPi system very quickly and test things. Also it may be used as a Debian based Linux system with a small footprint for development purposes, e.g. with the X11 window system. The small footprint makes it optimally usable on PCs without a huge built in RAM. Also several VMs may be run for different applications.
 
@@ -194,7 +197,7 @@ Select the following tabs for the installation description of your target.
     ![DietPi-VirtualBox-program](assets/images/dietpi-VirtualBox-program.png)
 
 
-    ## Prerequisites
+    <font size="+2">Prerequisites</font>
 
     As a starting point you need a **PC with a running VirtualBox software** on which the DietPi system will run.  
     On this PC a free harddisk space of about  
@@ -204,8 +207,7 @@ Select the following tabs for the installation description of your target.
 
     is needed. A recommended size is at least a free space of 10 GB.
 
-
-    ## 1. Download and extract the DietPi disk image
+    <font size="+2">1. Download and extract the DietPi disk image</font>
 
     Download the **DietPi VirtualBox file** "DietPi_VirtualBox-x86_64-Buster.7z" from [dietpi.com](https://dietpi.com/#download) and   
     unzip the downloaded file to a local!!! info "DietPi Survey" folder. It is a _7z_ archive format so you will need to install either [7zip for Windows](https://www.7-zip.org/) or other alternative tools.
@@ -216,8 +218,8 @@ Select the following tabs for the installation description of your target.
 
     ![Dietpi-zipfile-content](assets/images/dietpi-VirtualBox-7zip-file.png)
 
+    <font size="+2">2. Import of the .ova file in VirtualBox</font>
 
-    ## 2. Import of the .ova file in VirtualBox
     As next, the VirtualBox virtual machine has to be setup by importing the .ova file (via \File\Import Appliance):
 
     ![DietPi-import-VirtualBoxMachine1](assets/images/dietpi-VirtualBox-import1.png)
@@ -232,8 +234,8 @@ Select the following tabs for the installation description of your target.
 
     ![DietPi-VirtualBoxMachine1](assets/images/dietpi-VirtualBox-VB-Machine.png)
 
+    <font size="+2">3. First boot of the new VirtualBox image</font>
 
-    ## 3. First boot of the new VirtualBox image
     Press the start button (green arrow) to 'boot up' your system based on the DietPi image.
     If you do not have a wired LAN connection you have to change the network settings matching to your environment (files `\boot\dietpi.txt` and `\boot\dietpi-wifi.txt`).
 
@@ -244,14 +246,12 @@ After the system has booted up, you can continue following the instructions on t
 - If you have a keyboard and a monitor connected to your system you login via this console.
 - If you have a headless system (e.g. an SBC without keyboard resp. monitor) you have to use a terminal program (e.g. `putty`) to connect to the system via an ssh connection.
 
-A login prompt should appear.
-
-Initial credentials:
+A login prompt will appear. Use the initial credentials:
 
 - login: **root**
 - password: **dietpi**
 
-??? info "Click here if you want to connect via network (running a _headless install_)"
+??? hint "Click here if you want to connect via network (running a _headless install_)"
 
     **WARNING**
 

--- a/docs/user-guide_installation.md
+++ b/docs/user-guide_installation.md
@@ -83,7 +83,7 @@ Select the following tabs for the installation description of your target.
     ![DietPi-Etcher-install-03](assets/images/DietPi-Etcher-install-03.jpg)
 
     ??? info "Click here if you want to pre-configure WiFi network "
-        To setup Wifi, open the SD card folder, and update next two files using a text editor of your choice:
+        To setup the WiFi, open the SD card folder, and update next two files using a text editor of your choice:
 
         1.  Open the file named `dietpi.txt`. Find `AUTO_SETUP_NET_WIFI_ENABLED` and set to value 1.
         2.  Open the file `dietpi-wifi.txt` and set `aWIFI_SSID[0]` to the name of your WiFi network.

--- a/docs/user-guide_installation.md
+++ b/docs/user-guide_installation.md
@@ -311,8 +311,8 @@ If you want to make further changes to your DietPi configuration, you can run `d
 
 For more details, check [DietPi Tools](../dietpi_tools) section.
 
-## 6. Install by community (YouTube)
+## YouTube tutorial (made by community)
 
-A video tutorial on _How to install and initially configure DietPi_ by Roberto Jorge.
+A video tutorial on _How to install and initially configure DietPi_ made by Roberto Jorge.
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Me0PfuNLl-Q?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope" allowfullscreen></iframe>

--- a/docs/user-guide_overview.md
+++ b/docs/user-guide_overview.md
@@ -19,24 +19,28 @@ Once you run `dietpi-launcher` you could see all available DietPi tools. It prov
 ## DietPi-Software -- Choose the software you need
 
 The base installation of DietPi is minimal **by design**, allowing you to choose what software you want to install and use. If you’re unsure what software to install, checkout [DietPi Optimised Software](../dietpi_optimised_software) page for more details.  
-The list includes desktop environments, Remote Desktop, Media Systems/Players, Torrents/Downloading (Transmission), Cloud/Backup, Gaming, Social, Surveillance, Hotspots, System Stats, Hardware Projects, Stacks (LAMP/LEMP), Pi-hole, PiVPN, File Servers, Home Automation, Printing, and [much more...](../dietpi_optimised_software).
+
+The list of optimised software includes:
+
+- desktop environments
+- Remote Desktops
+- Media Systems/Players
+- Torrents/Downloading (Transmission)
+- Cloud/Backup
+- Gaming
+- Social
+- Hotspots
+- System Stats
+- Hardware Projects
+- Stacks (LAMP/LEMP etc.)
+- File Servers
+- Home Automation
+- Printing
+- and [much more...](../dietpi_optimised_software).
+
+To install and configure them use `dietpi-software` tool - [click for more details](../dietpi_tools/#dietpi-software).
 
 ![DietPi Software](assets/images/dietpi-software.jpg)
-
-??? info "How do I run `dietpi-software` and install **optimised software**?"
-
-    This tool will automatically launch when you first boot your Raspberry Pi using DietPi after the initial configuration process has completed. You can also launch it manually by typing `dietpi-software` in the terminal.
-
-    - To begin, select **Software Optimized** in the main menu list and hit Enter.    
-    - Scroll through the list of available software - for more details check [DietPi Optimised Software](../dietpi_optimised_software)
-    - To install software on your DietPi, select it in the list and press the **space bar** to add it to the installation list. If you change your mind, hit space again to remove it.
-    - Once you’ve selected the software you wish to install, press the tab key on your keyboard to switch to the confirmation options at the bottom. Select **OK**, then hit enter on your keyboard to confirm.
-    - To begin installing your software, select **Install** from the main menu list, then hit the Enter key. DietPi will ask you to confirm your choice(s). Select **OK**, then hit enter to begin the installation.
-
-    The software you selected will begin to install at this point.  
-    Once the process is completed, you may be asked to restart your device. Press **OK** to confirm.
-
-You can return to the **DietPi-Software** tool to make further changes at any time by typing `dietpi-software` at the terminal, or enter `dietpi-launcher` and select **DietPi-Software** tool.
 
 ## Supported SBC
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,9 +47,9 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.mark
   - pymdownx.smartsymbols
-  - pymdownx.snippets:
-      check_paths: true
+  - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.highlight
   - pymdownx.tabbed
   - pymdownx.tasklist:
       custom_checkbox: true
@@ -124,7 +124,7 @@ nav:
       - 'Optimised software list' : 'dietpi_optimised_software.md'
       - 'Supported SBC' : 'dietpi_sbc.md'
       - 'Community Tutorials' : 'https://dietpi.com/phpbb/viewforum.php?f=15'
-      - 'Advanced configuration & DietPi Tools' : 'dietpi_tools.md'
+      - 'Advanced configuration' : 'dietpi_tools.md'
       - 'Troubleshooting' : 'https://dietpi.com/phpbb/viewforum.php?f=11'
       - 'Release notes' : 'release-notes.md'
       - 'Request features' : 'https://github.com/MichaIng/DietPi/issues/new/choose'


### PR DESCRIPTION
This PR contains more changes:

- install guide: headers are not fully supported by MkDocs Material in the tabs; this brought to a duplication to the right side index. Resolved by simulating the section using an increased font.

- simplified the tools page & extend the dietpi-software description

- update of the release notes to include the new software title & docker updates
  