### PR TITLE
WiFi spelling

### DIFF
--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -12,7 +12,7 @@ matrix:
     - title
     - alt
     ignores:
-    - :matches(code, pre)
+    - ':is(code, pre)'
   - pyspelling.filters.url:
   sources:
   - build/docs/**/*.html|!build/docs/release-notes/*|!build/docs/dietpi_docs_todo/*|!build/docs/overrides/*

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -12,8 +12,7 @@ matrix:
     - title
     - alt
     ignores:
-    - code
-    - pre
+    - :matches(code, pre)
   - pyspelling.filters.url:
   sources:
   - build/docs/**/*.html|!build/docs/release-notes/*|!build/docs/dietpi_docs_todo/*|!build/docs/overrides/*

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -310,8 +310,7 @@ webserver
 Webservers
 Webserves
 Widevine
-Wifi
-wifi
+WiFi
 WireGuard
 WiringPi
 Wordpress


### PR DESCRIPTION
On the DietPi repository I tend to use "WiFi" consequently. This fits to the certificate alliance logo:

![WiFi logo](https://upload.wikimedia.org/wikipedia/commons/f/f8/Wi-FI_Alliance_Logo.png)

However, considering the word was derived from "Hi-Fi", actually "Wi-Fi" should be correct, which is also supported by the Wikipedia page: https://en.wikipedia.org/wiki/Wi-Fi
And the Wi-Fi Alliance website: https://www.wi-fi.org/

So basically I'd not use "Wifi" at least and in regular text definitely not "wifi" and even that is really I tiny irrelevant topic in general, let's stick with a consistent spelling for such technical words/abbreviations as well as brand/product names 😃.