### PR TITLE
Simplify link checks

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,7 +38,7 @@ jobs:
         if: always() && steps.build.outcome == 'success'
         run: |
           GO111MODULE=on go get -u github.com/raviqqe/liche
-          $(go env GOPATH)/bin/liche -d build -x 'http://localhost|http://192.168.0.100|https://github.com' -r README.md build/docs
+          $(go env GOPATH)/bin/liche -v -x 'http://localhost|http://192.168.0.100|https://github.com' -d build -r README.md build/docs
       - name: Check spelling in HTML files
         if: always() && steps.build.outcome == 'success'
         # .spellcheck.yml: https://github.com/marketplace/actions/github-spellcheck-action#spellcheck-configuration-file

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,15 +34,11 @@ jobs:
         id: build
         if: always() && steps.mkdocs_config.outcome == 'success'
         run: mkdocs build -sd build/docs
-      - name: Check links in HTML files
-        id: check_links
+      - name: Check links in HTML and Markdown files
         if: always() && steps.build.outcome == 'success'
-        uses: peter-evans/link-checker@v1
-        with:
-          args: -d build -x http://localhost|http://192.168.0.100|https://github.com -r README.md build/docs
-      - name: Check link check result
-        if: always() && steps.check_links.outcome == 'success'
-        run: exit ${{ steps.check_links.outputs.exit_code }}
+        run: |
+          GO111MODULE=on go get -u github.com/raviqqe/liche
+          $(go env GOPATH)/bin/liche -d build -x http://localhost|http://192.168.0.100|https://github.com -r README.md build/docs
       - name: Check spelling in HTML files
         if: always() && steps.build.outcome == 'success'
         # .spellcheck.yml: https://github.com/marketplace/actions/github-spellcheck-action#spellcheck-configuration-file

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,7 +38,7 @@ jobs:
         if: always() && steps.build.outcome == 'success'
         run: |
           GO111MODULE=on go get -u github.com/raviqqe/liche
-          $(go env GOPATH)/bin/liche -d build -x http://localhost|http://192.168.0.100|https://github.com -r README.md build/docs
+          $(go env GOPATH)/bin/liche -d build -x 'http://localhost|http://192.168.0.100|https://github.com' -r README.md build/docs
       - name: Check spelling in HTML files
         if: always() && steps.build.outcome == 'success'
         # .spellcheck.yml: https://github.com/marketplace/actions/github-spellcheck-action#spellcheck-configuration-file

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,7 +38,7 @@ jobs:
         if: always() && steps.build.outcome == 'success'
         run: |
           GO111MODULE=on go get -u github.com/raviqqe/liche
-          $(go env GOPATH)/bin/liche -v -x 'http://localhost|http://192.168.0.100|https://github.com' -d build -r README.md build/docs
+          $(go env GOPATH)/bin/liche -v -x 'https://github.com' -d build -r README.md build/docs
       - name: Check spelling in HTML files
         if: always() && steps.build.outcome == 'success'
         # .spellcheck.yml: https://github.com/marketplace/actions/github-spellcheck-action#spellcheck-configuration-file

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It uses extended Markdown, as implemented by [MkDocs](https://www.mkdocs.org/).
 - Install dependencies: `pip3 install -r requirements.txt`
 - From the root directory, run: `mkdocs serve`
 
-It builds the static HTML pages into the `site` directory and starts a local web server at <http://localhost:8000>. If you have troubles accessing the MkDocs website, you could also listen on a specific IP address or all IP addresses, e.g. `mkdocs serve -a 0.0.0.0:8000`.
+It builds the static HTML pages into a temporary directory and starts a local web server at `http://localhost:8000`. If you have troubles accessing the MkDocs website, you could also listen on a specific IP address or all IP addresses, e.g. `mkdocs serve -a 0.0.0.0:8000`.
 
 ## License
 

--- a/docs/software/bittorrent.md
+++ b/docs/software/bittorrent.md
@@ -38,7 +38,7 @@ Key features:
     Search for matching subtitles on a regular basis and upgrade the one you previously downloaded if a better one is found.
 
 === "Quick start"
-    After installation access the web interface using port **6767** (ex: http://192.168.0.100:6767)
+    After installation access the web interface using port **6767** (e.g.: `http://192.168.0.100:6767`)
 
     ![Bazarr](../assets/images/dietpi-software-download-bazarr.jpg)
 

--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -42,7 +42,7 @@ Nextcloud gives you access to all your files wherever you are. Store your docume
 
 === "Quick start"
 
-    Access the web interface using the next URL when running on SBC (<http://localhost/nextcloud/>) or the IP address / hostname of your DietPi device (e.g.: [http://192.168.0.100/nextcloud/](<http://192.168.0.100/nextcloud/>)).
+    Access the web interface using the next URL when running on SBC (`http://localhost/nextcloud/`) or the IP address / hostname of your DietPi device (e.g.: `http://192.168.0.100/nextcloud/`).
 
     ```
     username = admin

--- a/docs/software/remote_desktop.md
+++ b/docs/software/remote_desktop.md
@@ -50,7 +50,7 @@ Run a **Desktop environment** on your device and access it accessed remotely via
 
     Connection Details:
 
-    - Use the IP address of your DietPi device (e.g.: 192.168.0.100). If you can't connect, try connecting to screen 1 (e.g.: 192.168.0.100:1)
+    - Use the IP address of your DietPi device (e.g.: `192.168.0.100`). If you can't connect, try connecting to screen 1 (e.g.: `192.168.0.100:1`)
     - Use the password you entered during the installation. If you would like to change the password run from the console/terminal
     ```
     vncpasswd

--- a/docs/user-guide_installation.md
+++ b/docs/user-guide_installation.md
@@ -278,7 +278,7 @@ A login prompt will appear. Use the initial credentials:
     - A popular SSH Client for Windows is PUTTY. You can download putty from [here](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html). Enter in the `Host Name` field the IP address found during the scanning, select `SSH` and then click on _Open_ button.
     ![DietPi-ssh](assets/images/dietpi-ssh.jpg)
 
-    - Most Linux distributions come packaged with an ssh client. Type in your Terminal next command (replace the sample IP address 192.168.1.20 with the one found via scanning the network):  
+    - Most Linux distributions come packaged with an ssh client. Type in your Terminal next command (replace the sample IP address `192.168.1.20` with the one found via scanning the network):  
     ```
     ssh root@192.168.1.20
     ```


### PR DESCRIPTION
Use liche directly instead of link-checker overhead with Docker, probably outdated liche etc. That way we see the command output live, get a check result directly and are sure that arguments are passed as we define them.

Additionally, example URLs, like `192.168.0.100` or `localhost` should not be clickable links, hence those are wrapped now into `<code>` tag. This allows to remove them from link check (liche) exclusion.

And a small one: `mkdocs serve` does not build to the `site` directory, but into a temporary directory `/tmp/mkdocs-<something>` and serves the site from there.