### PR TITLE
Diet-Software | Gogs

### DIFF
--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -330,9 +330,9 @@ Your very own GitHub style server, with web interface.
     Has to be done once, when connected to the web interface:
 
     - Change the following values only:
-        - Host = `/run/mysqld/mysqld.sock`
+        - Database = `MySQL`
         - User = `gogs`
-        - Database password = `dietpi`
+        - Database password = `<your global password>`
         - Repository Root Path = `/mnt/dietpi_userdata/gogs-repo`
         - Run User = `gogs`
         - Log Path = `/var/log/gogs`


### PR DESCRIPTION
+ Diet-Software | Gogs: Update connection details database typ + global password

For the database it's needed to change to `MySQL` as per default it's set to `PostgreSQL`. Host information will be adjusted automatically. No need to enter any host string. 

As well database password is the global one now and not the old good `dietpi`