### PR TITLE
Remove CloudPrint and align list

### DIFF
--- a/docs/dietpi_optimised_software.md
+++ b/docs/dietpi_optimised_software.md
@@ -13,6 +13,14 @@
 
     To see all the DietPi configurations options, review [DietPi Tools](../dietpi_tools) section.
 
+## [Advanced Networking](../software/advanced_networking/)
+
+- [**WiFi HotSpot - Turn your device into a wireless hotspot/access point**](../software/advanced_networking/#wifi-hotspot)
+- [**Tor HotSpot - Optional: Routes all WiFi hotspot traffic through the Tor network**](../software/advanced_networking/#tor-hotspot)
+- [**Tor Relay - Add a node to the Tor network**](../software/advanced_networking/#tor-relay)
+- [**HAProxy - High performance TCP/HTTP load balancer**](../software/advanced_networking/#haproxy)
+- [**No-IP - Website URL Address**](../software/advanced_networking/#no-ip)
+
 ## [BitTorrent & Download Tools](../software/bittorrent/)
 
 - [**Transmission - Lightweight BitTorrent server with web interface**](../software/bittorrent/#transmission)
@@ -79,7 +87,6 @@
 
 - [**Pi-hole - Network-wide Ad Blocking**](../software/dns_servers/#pi-hole)
 - [**Unbound - A validating, recursive, and caching DNS resolver**](../software/dns_servers/#unbound)
-- [**No-IP - Website URL Address**](../software/dns_servers/#no-ip)
 
 ## [File Server](../software/file_servers/)
 
@@ -157,14 +164,8 @@
 - [**Raspotify - Spotify Connect client**](../software/media/#raspotify)
 - [**Spotify Connect Web - Web interface, client and player for Spotify Premium**](../software/media/#spotify-connect-web)
 
-## [Advanced Networking](../software/advanced_networking/)
-
-- [**HAProxy - High performance TCP/HTTP load balancer**](../software/advanced_networking/#haproxy)
-- [**Tor Relay - Add a node to the Tor network**](../software/advanced_networking/#tor-relay)
-
 ## [Printing Server](../software/printing/)
 
-- [**CloudPrint - CUPS print server, with support for Google cloud printing**](../software/printing/#cloudprint)
 - [**OctoPrint - Web interface for controlling 3D printers**](../software/printing/#octoprint)
 
 ## [Remote Desktop & Remote Access](../software/remote_desktop/)
@@ -250,8 +251,3 @@
 
 - Python 3 & Flask - Micro web framework powered by Python
 - PHP - scripting language especially suited to web development
-
-## [WiFi Access Points](../software/wifi_hotspot/)
-
-- [**WiFi HotSpot - Turn your device into a wireless hotspot/access point**](../software/wifi_hotspot/#wifi-hotspot)
-- [**Tor HotSpot - Optional: Routes all WiFi hotspot traffic through the Tor network**](../software/wifi_hotspot/#tor-hotspot)

--- a/docs/software/printing.md
+++ b/docs/software/printing.md
@@ -2,7 +2,6 @@
 
 ## Overview
 
-- [**CloudPrint - CUPS print server, with support for Google cloud printing**](#cloudprint)
 - [**OctoPrint - Web interface for controlling 3D printers**](#octoprint)
 
 ??? info "How do I run **DietPi-Software** and install **optimised software** ?"
@@ -19,54 +18,6 @@
     To see all the DietPi configurations options, review [DietPi Tools](../../dietpi_tools) section.
 
 [Return to the **Optimised Software list**](../../dietpi_optimised_software)
-
-## CloudPrint
-
-The package is based on the CUPS print server. It supports also the Google cloud printing.  
-Also included is a web interface for CUPS, allowing easy setup of printers.
-
-![DietPi print server software CUPS](../assets/images/dietpi-software-printserver-cups.png){: style="width:550px"}
-
-=== "Access the web interface"
-
-    The web interface is accessible via port 631 on the machine running the CUPS server, e.g. this could be:  
-
-    - URL = `http://192.168.0.100:631`  
-    - user = `root`  
-    - password = `dietpi`
-
-=== "Add a printer"
-
-    In the CUPS web interface, you can add and configure printers by selecting:
-
-    - *Home* \> *Adding Printers and Classes*
-
-=== "Enable CloudPrint"
-
-    Once the printer is setup you only have to run the following command to enable Google Cloud Print authentication on this device:
-
-    ```
-    cps-auth
-    ```
-
-    An URL will be generated. Use this URL link in a web browser to complete the authentication.  
-    Afterwards restart the services with:
-
-    ```
-    dietpi-services restart
-    ```
-
-    If you experience issues, you can check the status of the CloudPrint service for info with:
-
-    ```
-    systemctl status cloudprintd -l
-    ```
-
-=== "Print"
-
-    Your printer should now be available from <https://www.google.com/cloudprint/#printers>.
-
-See also <https://wikipedia.org/wiki/Common_Unix_Printing_System> resp. <https://www.cups.org/>.
 
 ## OctoPrint
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
       - 'Request features' : 'https://github.com/MichaIng/DietPi/issues/new/choose'
       - 'Report issues' : 'https://github.com/MichaIng/DietPi/issues'
   - 'OPTIMISED SOFTWARE' :
+      - 'Advanced Networking' : 'software/advanced_networking.md'
       - 'BitTorrent & Download Tools' : 'software/bittorrent.md'
       - 'Camera & Surveillance' : 'software/camera.md'
       - 'Cloud & Backup Systems' : 'software/cloud.md'
@@ -144,7 +145,6 @@ nav:
       - 'Home Automation' : 'software/home_automation.md'
       - 'Logging Systems' : 'software/log_system.md'
       - 'Media Systems': 'software/media.md'
-      - 'Advanced Networking' : 'software/advanced_networking.md'
       - 'Printing Servers' : 'software/printing.md'
       - 'Remote Desktop & Remote Access' : 'software/remote_desktop.md'
       - 'Social & Search' : 'software/social.md'


### PR DESCRIPTION
CloudPrint service ends with the end of the year and the install option has been disabled in DietPi to not offer an option that is functional for some ~2 weeks only.

WiFi HotSpot, Tor HotSpot and No-IP have been moved to the Advanced Networking category. Move it to the top of the list to stay with alphabetical order. WiFi HotSpot/AP category has been removed.