### PR TITLE
Show Tor Relay image smaller

### DIFF
--- a/docs/software/advanced_networking.md
+++ b/docs/software/advanced_networking.md
@@ -82,7 +82,7 @@ See also <https://wikipedia.org/wiki/Tor_(anonymity_network)>.
 
 ## Tor Relay
 
-![advanced-networking-tor](../assets/images/dietpi-software-advanced-networking-tor.png){: style="width:500px"}
+![advanced-networking-tor](../assets/images/dietpi-software-advanced-networking-tor.png){: style="width:150px"}
 
 Contribute a node to the Tor network, which allows people to be anonymous on the internet.
 


### PR DESCRIPTION
500 px for a simple image seems to be too big.  
Other icons also were shown much smaller for a more convenient design.