### PR TITLE
Enhance/fix IceCast docs

### DIFF
--- a/docs/software/media.md
+++ b/docs/software/media.md
@@ -715,46 +715,39 @@ Shoutcast streaming server, includes DarkIce for audio input (e.g.: microphone).
 
 === "Installation notes"
 
-    DietPi will attempt to detect mic input during installation, and apply to DarkIce. If a microphone was not available, or you experience issue, check available microphones with:
+    DietPi will attempt to detect mic input during installation, and apply to DarkIce. If a microphone was not available, or you experience issue, check available microphones with: `arecord -l`
 
-      `arecord -l`
+    - Then edit the device entry in `/etc/darkice.cfg`, or  
+    - Simple copy and paste:
 
-      - Then edit the device entry in `/etc/darkice.cfg`, or  
-      - Simple copy and paste:
+      ```sh
+      sed -i "/^device[[:blank:]]/c\device = hw:$(arecord -l | mawk -F'[ :]' '/card/{print $2;exit}'),0" /etc/darkice.cfg
+      ```
 
-        ```sh
-        sed -i "/^device[[:space:]]/c\device = hw:$(arecord -l | grep -m1 'card' | awk '{print $2}' | sed 's/://'),0" /etc/darkice.cfg
-        ```
+    - Restart services: `dietpi-services restart`
 
-      - Restart services
-
-        ```sh
-        dietpi-services restart
-        ```
-
-    We created a `systemd` service for DarkIce, DietPi will automatically start this:  
-    `systemctl status darkice -l`
+    We created a `systemd` service for DarkIce, DietPi will automatically start this: `systemctl -l status darkice`
 
 === "Access IceCast web interface"
 
     - URL = `http://<your.IP>:8000`
-    - Source password = `dietpi`
-    - Relay password = `dietpi`
+    - Admin user = `admin`
     - Admin password = randomly generated, use code below to view:
 
         ```sh
-        cat /etc/icecast2/icecast.xml | grep admin-password
+        grep admin-password /etc/icecast2/icecast.xml
         ```
+
+    - Source password = `dietpi`
+    - Relay password = `dietpi`
 
 === "Access Recording File"
 
     This is disabled by default.
 
     - A recording of the stream can be enabled by edit of `/etc/darkice.cfg`, then uncomment `localDumpFile = /mnt/dietpi_userdata/darkice_recording.ogg`
-    - Restart services:  
-      `dietpi-services restart`
-    - A recording will then be saved in the following location:  
-      `/mnt/dietpi_userdata/darkice_recording.ogg`
+    - Restart services: `dietpi-services restart`
+    - A recording will then be saved in the following location: `/mnt/dietpi_userdata/darkice_recording.ogg`
 
 ## Koel
 

--- a/docs/software/media.md
+++ b/docs/software/media.md
@@ -720,13 +720,17 @@ Shoutcast streaming server, includes DarkIce for audio input (e.g.: microphone).
     - Then edit the device entry in `/etc/darkice.cfg`, or  
     - Simple copy and paste:
 
-      ```sh
-      sed -i "/^device[[:blank:]]/c\device = hw:$(arecord -l | mawk -F'[ :]' '/card/{print $2;exit}'),0" /etc/darkice.cfg
-      ```
+        ```sh
+        sed -i "/^device[[:blank:]]/c\device = hw:$(arecord -l | mawk -F'[ :]' '/card/{print $2;exit}'),0" /etc/darkice.cfg
+        ```
 
     - Restart services: `dietpi-services restart`
 
-    We created a `systemd` service for DarkIce, DietPi will automatically start this: `systemctl -l status darkice`
+    We created a `systemd` service for DarkIce, DietPi will automatically start it. You can check its status by running the following command:
+
+    ```sh
+    systemctl -l status darkice
+    ```
 
 === "Access IceCast web interface"
 
@@ -745,7 +749,12 @@ Shoutcast streaming server, includes DarkIce for audio input (e.g.: microphone).
 
     This is disabled by default.
 
-    - A recording of the stream can be enabled by edit of `/etc/darkice.cfg`, then uncomment `localDumpFile = /mnt/dietpi_userdata/darkice_recording.ogg`
+    - A recording of the stream can be enabled by edit of `/etc/darkice.cfg`, then uncomment
+    
+        ```
+        localDumpFile = /mnt/dietpi_userdata/darkice_recording.ogg
+        ```
+
     - Restart services: `dietpi-services restart`
     - A recording will then be saved in the following location: `/mnt/dietpi_userdata/darkice_recording.ogg`
 


### PR DESCRIPTION
Especially the web UI admin/login user name was missing, but simplified the shell commands a bit as well and removed the extra line break for inline code commands, that looks somehow strange to me.