### PR TITLE
Extend web development tools documentation

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -150,6 +150,7 @@ hotspot
 HotSpot
 hotspots
 htop
+http
 HQPlayer
 HTPC
 HTTPS
@@ -184,6 +185,7 @@ LASP
 lcd
 LEDs
 LEMP
+Lerdorf
 LESP
 LetsEncrypt
 LGPL
@@ -291,6 +293,7 @@ PSU
 PuTTY
 Pydio
 pyenv
+PyPi
 qBittorrent
 Queneuder
 QuiteRSS
@@ -299,6 +302,7 @@ Radarr
 Radxa
 RAMdisk
 RAMlog
+Rasmus
 Raspbian
 Raspotify
 rcon

--- a/docs/dietpi_optimised_software.md
+++ b/docs/dietpi_optimised_software.md
@@ -221,34 +221,31 @@
 
 ## [Web development](../software/webserver_stack/)
 
-!!! warning "Documentation in progress..."
-    The **Optimised Software** links marked in **bold** have a more detailed description. The other links redirect to the old documentation (available on [DietPi.com Forum](https://dietpi.com/phpbb/viewtopic.php?t=5))  
-
 ### [Stacks for web development](../software/webserver_stack/#stacks-for-web-development)
 
-- [**LAMP Webserver - Apache2 / MariaDB / PHP**](../software/webserver_stack/#lamp-webserver-apache2-mariadb-php)  
-- [LASP Webserver - Apache2 / SQLite / PHP](https://dietpi.com/phpbb/viewtopic.php?p=52#p52)  
-- [LEMP Webserver - Nginx / MariaDB / PHP](https://dietpi.com/phpbb/viewtopic.php?p=53#p53)  
-- [LESP Webserver - Nginx / SQLite / PHP](https://dietpi.com/phpbb/viewtopic.php?p=53#p53)  
-- [LLMP Webserver - Lighttpd / MariaDB / PHP](https://dietpi.com/phpbb/viewtopic.php?p=1335#p1335)  
-- [LLSP Webserver - Lighttpd / SQLite / PHP](https://dietpi.com/phpbb/viewtopic.php?p=1335#p1335)  
+- [**LAMP** web stack - **Apache2 / MariaDB / PHP**](../software/webserver_stack/#lamp-web-stack)
+- [**LASP** web stack - **Apache2 / SQLite / PHP**](../software/webserver_stack/#lasp-web-stack)
+- [**LEMP** web stack - **Nginx / MariaDB / PHP**](../software/webserver_stack/#lemp-web-stack)
+- [**LESP** web stack - **Nginx / SQLite / PHP**](../software/webserver_stack/#lesp-web-stack)  
+- [**LLMP** web stack - **Lighttpd / MariaDB / PHP**](../software/webserver_stack/#llmp-web-stack)
+- [**LLSP** web stack - **Lighttpd / SQLite / PHP**](../software/webserver_stack/#llsp-web-stack)
 
 ### [Webservers](../software/webserver_stack/#webservers)
 
-- [Apache2 - Feature-rich webserver](https://dietpi.com/phpbb/viewtopic.php?p=1549#p1549)  
-- [Nginx - Lightweight webserver](https://dietpi.com/phpbb/viewtopic.php?p=1549#p1549)  
-- [Lighttpd - Extremely lightweight webserver](https://dietpi.com/phpbb/viewtopic.php?p=1549#p1549)
-- [Tomcat8 - Apache Tomcat server](https://dietpi.com/phpbb/viewtopic.php?p=4316#p4316)  
+- [**Apache2** - Feature-rich webserver](../software/webserver_stack/#apache2)  
+- [**Nginx** - High performance web server, load balancer & reverse proxy](../software/webserver_stack/#nginx)  
+- [**Lighttpd** - Extremely lightweight webserver](../software/webserver_stack/#lighttpd)
+- [**Tomcat8** - Apache Tomcat server](../software/webserver_stack/#tomcat)  
 
 ### [Databases & Data stores](../software/webserver_stack/#databases-data-stores)
 
-- MariaDB - Open Source Relational Database
-- [phpMyAdmin - SQL Administration Tool for MariaDB](https://dietpi.com/phpbb/viewtopic.php?p=54#p54)  
-- SQLite - Small, Fast and High reliable SQL database engine
-- Redis - Open Source In-memory key–value Data Store
-- InfluxDB - Open Source Time Series Database
+- [**MariaDB** - Open Source Relational Database](../software/webserver_stack/#mariadb)
+  - [**phpMyAdmin** - SQL Administration Tool for MariaDB](../software/webserver_stack/#phpmyadmin)  
+- [**SQLite** - Small, Fast and High reliable SQL database engine](../software/webserver_stack/#sqlite)
+- [**Redis** - Open Source In-memory key–value Data Store](../software/webserver_stack/#redis)
+- [**InfluxDB** - Open Source Time Series Database](../software/webserver_stack/#influxdb)
 
 ### [Programming & Web development Frameworks](../software/webserver_stack/#web-development-programming-frameworks)
 
-- Python 3 & Flask - Micro web framework powered by Python
-- PHP - scripting language especially suited to web development
+- [**Flask** - Micro web framework powered by Python](../software/webserver_stack/#flask)
+- [**PHP** - Scripting language especially suited to web development](../software/webserver_stack/#php)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -140,7 +140,7 @@ Many thanks to @CactiChameleon9 for implementing this software option (MichaIng/
 
 - **[DietPi-Config](../dietpi_tools/#configuration)** :octicons-arrow-right-16: Resolved an issue on RPi where selecting the waveshare32 LCD panel installed an outdated device tree overlay, incompatible with the current Linux 5.4 kernel. Many thanks to @black00019 for reporting this issue: <https://github.com/MichaIng/DietPi/issues/3881>
 
-- **[DietPi-Services]((../dietpi_tools/#configuration))** :octicons-arrow-right-16: Resolved an issue where CPU affinity selection failed due to a syntax error.
+- **[DietPi-Services](../dietpi_tools/#configuration)** :octicons-arrow-right-16: Resolved an issue where CPU affinity selection failed due to a syntax error.
 
 - **DietPi-Bugreport** :octicons-arrow-right-16: Resolved an issue where bug report uploads were cancelled if connection test on port 80/443 failed even that uploads are done via SFTP on port 22.
 
@@ -172,7 +172,7 @@ Many thanks to @CactiChameleon9 for implementing this software option (MichaIng/
 
 - **[DietPi-Software | Mycroft AI](../software/hardware_projects/#mycroft-ai)** :octicons-arrow-right-16: Resolved an issue where skill installs failed due to missing permissions. Many thanks to [phpBB:GreenGentleman](https://dietpi.com/phpbb/memberlist.php?username=GreenGentleman) for reporting this issue: <https://dietpi.com/phpbb/viewtopic.php?p=28464#p28464>
 
-- **[DietPi-Software | Jellyfin](../docs/software/media/#jellyfin)** :octicons-arrow-right-16: Resolved an issue where Jellyfin did not run on ARMv6 (RPi 1 and Zero models). ARMv6/Raspbian-compatible binaries are now shipped via different APT repository. Many thanks to [phpBB:Shiivu](https://dietpi.com/phpbb/memberlist.php?username=Shiivu) for reporting this issue: <https://dietpi.com/phpbb/viewtopic.php?t=8263>
+- **[DietPi-Software | Jellyfin](../software/media/#jellyfin)** :octicons-arrow-right-16: Resolved an issue where Jellyfin did not run on ARMv6 (RPi 1 and Zero models). ARMv6/Raspbian-compatible binaries are now shipped via different APT repository. Many thanks to [phpBB:Shiivu](https://dietpi.com/phpbb/memberlist.php?username=Shiivu) for reporting this issue: <https://dietpi.com/phpbb/viewtopic.php?t=8263>
 
 - **[DietPi-Software | WiFi Hotspot](../software/advanced_networking/#wifi-hotspot)** :octicons-arrow-right-16: Resolved an issue on RPi with WiFi adapters using an RTL8188C* chip, where the service failed to start due to an invalid driver. Many thanks to [phpBB:yerc](https://dietpi.com/phpbb/memberlist.php?username=yerc) for reporting this issue: <https://dietpi.com/phpbb/viewtopic.php?p=28984#p28984>
 

--- a/docs/software/webserver_stack.md
+++ b/docs/software/webserver_stack.md
@@ -539,7 +539,7 @@ Source: [MariaDB](https://mariadb.com/), [LGPL](https://commons.wikimedia.org/w/
 
 === "Official documentation"
 
-    - [MariaDB website: mariadb.org](https://mariadb.org)
+    - [MariaDB website](https://mariadb.org)
     - [Getting started documentation](https://mariadb.org/documentation/#getting-started)  
 
 #### phpMyAdmin
@@ -592,7 +592,7 @@ Source: [Carlos Prioglio](http://redis.io/images/redis-logo.svg), [licence](http
 
 === "Quick start"
 
-    The first thing to do in order to check Redis is working properly is sending a PING command using redis-cli:
+    The first thing to do in order to check Redis is working properly is sending a PING command:
 
     ``` bash
     redis-cli ping
@@ -612,7 +612,7 @@ Source: [Carlos Prioglio](http://redis.io/images/redis-logo.svg), [licence](http
 
 Source: [InfluxData](https://influxdata.github.io/design.influxdata.com/branding-docs/img/influxdb/preview.svg), [Public Domain](https://commons.wikimedia.org/w/index.php?curid=55056027).
 
-**InfluxDB** is a _time series_ database designed to handle high write and query loads. InfluxDB is not only a time series platform, but it provides also an Web UI and dashboarding tools, background processing and monitoring agent.
+**InfluxDB** is a _time series_ database designed to handle high write and query loads. InfluxDB is not only a time series platform, but it provides also an Web UI and dashboard tools, background processing and monitoring agent.
 
 === "Quick start"
 
@@ -706,7 +706,7 @@ Flask is a lightweight web application framework. It is designed to make getting
     - [User's guide & Documentation](https://flask.palletsprojects.com/en/1.1.x/)
     - [Flask website](https://palletsprojects.com/p/flask/)
     - [PyPi package page](https://pypi.org/project/Flask)
-    
+
 [^1]:
     Find out more about the success stories of Nginx on: <https://Nginx.org/en/>
 [^2]:

--- a/docs/software/webserver_stack.md
+++ b/docs/software/webserver_stack.md
@@ -437,7 +437,7 @@ LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
     - OPcache = `http://<your.IP>/opcache.php`
 
     For database, check **[MariaDB](#mariadb)** details.
-    
+
 === "Secured access - HTTPS/SSL"
 
     **Let's Encrypt** is highly recommended - [see here how to install](../../dietpi_tools/#lets-encrypt-ssl-nordvpn-support). This will automate the creation and setup of your free SSL cert.
@@ -485,6 +485,7 @@ The innovation of Nginx compared to earlier servers such as Apache was to use an
 === "Official documentation"
 
     - <https://www.nginx.com>
+
 ### Lighttpd
 
 **Lighttpd** is a web server for UNIX/Linux and Windows operating systems. It is an alternative to Apache web server. It is also called Lighty.
@@ -502,6 +503,7 @@ It is designed to be secure, fast, standards-compliant, and flexible while being
 === "Official documentation"
 
     - <https://www.lighttpd.net>
+
 ### Tomcat
 
 What is **Apache Tomcat**? Essentially it’s an open-source Java servlet and Java Server Page container that lets developers implement an array of enterprise Java applications. Tomcat also runs a HTTP web server environment in which Java code can run.
@@ -575,6 +577,7 @@ Source: Part of the SQLite documentation, which has been released by author D. R
 
     - [SQLite.org](https://www.sqlite.org/index.html)
     - [SQLite.org documentation](https://www.sqlite.org/docs.html)
+
 ### Redis
 
 A non-SQL based data store.
@@ -667,16 +670,15 @@ Source: [InfluxData](https://influxdata.github.io/design.influxdata.com/branding
     - [InfluxDB Get Started](https://docs.influxdata.com/influxdb/v2.0/get-started/#set-up-influxdb)
     - [InfluxDB website](https://www.influxdata.com/products/influxdb/)
 
-
 ## Web development - Programming & Frameworks
 
 ### PHP
 
-![DietPi Webstack software PHP logo](../assets/images/dietpi-software-webstack-php.svg){: style="width:150px"} 
+![DietPi Webstack software PHP logo](../assets/images/dietpi-software-webstack-php.svg){: style="width:150px"}
 
-Source: [Colin Viebrock](http://php.net/logos), [CC BY-SA 4.0](https://commons.wikimedia.org/w/index.php?curid=9632398).
+Source: [Colin Viebrock](https://www.php.net/download-logos.php), [CC BY-SA 4.0](https://commons.wikimedia.org/w/index.php?curid=9632398).
 
-First introduced by Rasmus Lerdorf, PHP is an open-source, server-side general scripting language that has now become a de-facto coding standard in the web development industry. 
+First introduced by Rasmus Lerdorf, PHP is an open-source, server-side general scripting language that has now become a de-facto coding standard in the web development industry.
 
 === "Quick start"
 
@@ -686,7 +688,6 @@ First introduced by Rasmus Lerdorf, PHP is an open-source, server-side general s
 
     - [PHP website](https://www.php.net)
     - [PHP manual](https://www.php.net/manual/en/index.php)
-
 
 ### Flask
 
@@ -706,7 +707,6 @@ Flask is a lightweight web application framework. It is designed to make getting
     - [Flask website](https://palletsprojects.com/p/flask/)
     - [PyPi package page](https://pypi.org/project/Flask)
     
-
 [^1]:
     Find out more about the success stories of Nginx on: <https://Nginx.org/en/>
 [^2]:

--- a/docs/software/webserver_stack.md
+++ b/docs/software/webserver_stack.md
@@ -2,34 +2,34 @@
 
 ## Overview
 
-[**Stacks for Web Development**](./#stacks-for-web-development)
+[**Stacks for Web Development**](#stacks-for-web-development)
 
-- [**LAMP** web stack - **Apache2 / MariaDB / PHP**](./#lamp-web-stack)
-- [**LASP** web stack - **Apache2 / SQLite / PHP**](./#lasp-web-stack)
-- [**LEMP** web stack - **Nginx / MariaDB / PHP**](./#lemp-web-stack)
-- [**LESP** web stack - **Nginx / SQLite / PHP**](./#lesp-web-stack)  
-- [**LLMP** web stack - **Lighttpd / MariaDB / PHP**](./#llmp-web-stack)
-- [**LLSP** web stack - **Lighttpd / SQLite / PHP**](./#llsp-web-stack)
+- [**LAMP** web stack - **Apache2 / MariaDB / PHP**](#lamp-web-stack)
+- [**LASP** web stack - **Apache2 / SQLite / PHP**](#lasp-web-stack)
+- [**LEMP** web stack - **Nginx / MariaDB / PHP**](#lemp-web-stack)
+- [**LESP** web stack - **Nginx / SQLite / PHP**](#lesp-web-stack)  
+- [**LLMP** web stack - **Lighttpd / MariaDB / PHP**](#llmp-web-stack)
+- [**LLSP** web stack - **Lighttpd / SQLite / PHP**](#llsp-web-stack)
 
-[**Web Servers**](./#webservers)
+[**Web Servers**](#webservers)
 
-- [**Apache2** - Feature-rich webserver](./#apache2)  
-- [**Nginx** - High performance web server, load balancer & reverse proxy](./#nginx)  
-- [**Lighttpd** - Extremely lightweight webserver](./#lighttpd)
-- [**Tomcat8** - Apache Tomcat server](./#tomcat)  
+- [**Apache2** - Feature-rich webserver](#apache2)  
+- [**Nginx** - High performance web server, load balancer & reverse proxy](#nginx)  
+- [**Lighttpd** - Extremely lightweight webserver](#lighttpd)
+- [**Tomcat8** - Apache Tomcat server](#tomcat)  
 
-[**Databases & Data stores**](./#databases-data-stores)
+[**Databases & Data stores**](#databases-data-stores)
 
-- [**MariaDB** - Open Source Relational Database](./#mariadb)
-  - [**phpMyAdmin** - SQL Administration Tool for MariaDB](./#phpmyadmin)  
-- [**SQLite** - Small, Fast and High reliable SQL database engine](./#sqlite)
-- [**Redis** - Open Source In-memory key–value Data Store](./#redis)
-- [**InfluxDB** - Open Source Time Series Database](./#influxdb)
+- [**MariaDB** - Open Source Relational Database](#mariadb)
+  - [**phpMyAdmin** - SQL Administration Tool for MariaDB](#phpmyadmin)  
+- [**SQLite** - Small, Fast and High reliable SQL database engine](#sqlite)
+- [**Redis** - Open Source In-memory key–value Data Store](#redis)
+- [**InfluxDB** - Open Source Time Series Database](#influxdb)
 
-[**Web development - Programming & Frameworks**](./#web-development-programming-frameworks)
+[**Web development - Programming & Frameworks**](#web-development-programming-frameworks)
 
-- [**Flask - Micro web framework powered by Python**](./#flask)
-- [**PHP** - Scripting language suited to web development](./#php)
+- [**Flask - Micro web framework powered by Python**](#flask)
+- [**PHP** - Scripting language suited to web development](#php)
 
 ??? info "How do I run **DietPi-Software** and install **optimised software** ?"
     To install any of the **DietPi optimised software** listed below run from the command line:
@@ -59,10 +59,10 @@ DietPi offers an **one-click-installation** of the following web development sta
 
 !!! hint "Meaning of the acronyms *LAMP*, *LASP*, *LEMP*, *LESP*, *LLMP*, *LLSP*"
 
-    - OS: **L** for Linux
-    - Webserver: **A** for Apache2, **E** for Nginx, **L** for Lighttpd
-    - Database: **M** for MariaDB, **S** for SQLite
-    - Scripting language: **P** for PHP
+    - OS: **L** for Linux / DietPi
+    - Webserver: **A** for Apache2, **E** for [Nginx](#nginx), **L** for [Lighttpd](#lighttpd)
+    - Database: **M** for MariaDB, **S** for [SQLite](#sqlite)
+    - Scripting language: **P** for [PHP](#php)
 
 !!! hint ""
     All stacks come with **PHP caches** (APCu and OPcache), being optimized based on a share of the total memory.
@@ -71,24 +71,25 @@ DietPi offers an **one-click-installation** of the following web development sta
 
 === "Which WEBSERVER to CHOOSE ?"
 
-    **Apache2**
+    **[Apache2](#apache2)**
 
     - Memory use = **High** | Multithreaded = **Yes**
 
-    Apache2 is feature-rich and popular. It is recommended for beginners and users who are looking to follow Apache2 based guides.
+    It is feature-rich and popular. It is recommended for beginners and users who are looking to follow Apache2 based guides.
 
-    **Nginx**
+    **[Nginx](#nginx)**
 
     - Memory use = **Medium** | Multithreaded = **Yes**
 
-    Nginx is a lightweight alternative to Apache2. Nginx claims faster webserver performance compared to Apache2. Ideal for medium-high traffic situations where Lighttpd will suffer.
+    It is a lightweight alternative to [Apache2](#apache2) and claims[^4] faster webserver performance compared to [Apache2](#apache2). It is ideal for medium-high traffic situations where [Lighttpd](#lighttpd) will suffer.
 
-    **Lighttpd**
+    **[Lighttpd](#lighttpd)**
 
     - Memory use = **Low** | Multithreaded = **Optional** - Some drawbacks
 
-    Lighttpd is extremely lightweight and is generally considered to offer the "best" webserver performance on Linux for SBCs (single board computers). It is recommended for users who expect low webserver traffic and/or personal use.  
-    Although the DietPi installation of Lighttpd is set to single threaded, do not be put off by this, in low usage scenarios (<10 users) it will still outperform Nginx and Apache2. Activation of multithreading is described in the Lighttpd package description.
+    It is extremely lightweight and is generally considered to offer the "best" webserver performance on Linux for SBCs (single board computers). It is recommended for users who expect low webserver traffic and/or personal use.  
+    
+    Although the DietPi installation of Lighttpd is set to single threaded, do not be put off by this, in low usage scenarios (<10 users) it will still outperform [Nginx](#nginx) and [Apache2](#apache2). Activation of multithreading is described in the [Lighttpd](#lighttpd) package description.
 
     **Further reading & benchmarks**
 
@@ -96,11 +97,11 @@ DietPi offers an **one-click-installation** of the following web development sta
 
 === "Which DATABASE to CHOOSE ?"
 
-    **MariaDB**  
-    [MariaDB](./#mariadb) is an open source RDBMS (relational data base management system). It is application compatible to MySQL, i.e. it can be used as a *drop in* replacement for MySQL. It has more features, fewer bugs, and a better performance compared to MySQL.
+    **[MariaDB](#mariadb)**  
+    It is an open source RDBMS (relational data base management system). It is application compatible to MySQL, i.e. it can be used as a *drop in* replacement for MySQL. It has more features, fewer bugs, and a better performance compared to MySQL.
 
-    **SQLite**  
-    SQLite is an RDBMS, also compatible to MySQL. It offers a broader language support (i.e. more bindings to programming languages) compared to [MariaDB](./#mariadb). SQLite has a very small footprint. As drawbacks, it has no multi user capabilities and a couple of SQL features are missing.
+    **[SQLite](#sqlite)**  
+    It is an RDBMS, also compatible to MySQL. It offers a broader language support (i.e. more bindings to programming languages) compared to [MariaDB](#mariadb). [SQLite](#sqlite) has a very small footprint. As drawbacks, it has no multi user capabilities and a couple of SQL features are missing.
 
 ### How to install ?
 
@@ -125,7 +126,7 @@ The latter is used only in the case of the first webserver background installati
     ![DietPi webserver selection webserver preference](../assets/images/dietpi-software-webserver-preference.png){: style="width:500px"}
 
     Using this option you only select the webserver for use in DietPi installations.  
-    When you select any software for installation that requires a webserver (e.g. Pi-hole, Nextcloud, Webmin, installed via *Software Optimized*), DietPi will automatically install, configure and optimize your chosen webserver preference. DietPi will also install [MariaDB](./#mariadb) / [SQLite](https://wikipedia.org/wiki/SQLite) as required, depending on your software selections. Basically, you will never need to manually select/install a webserver stack again. DietPi will do it all for you.
+    When you select any software for installation that requires a webserver (e.g. Pi-hole, Nextcloud, Webmin, installed via *Software Optimized*), DietPi will automatically install, configure and optimize your chosen webserver preference. DietPi will also install [MariaDB](#mariadb) / [SQLite](#sqlite) as required, depending on your software selections. Basically, you will never need to manually select/install a webserver stack again. DietPi will do it all for you.
 
     ???+ info "No webserver change if already installed"
         This setting "Webserver Preference* can NOT be changed if an existing webserver is installed on the system.
@@ -152,9 +153,7 @@ LAMP stack is a popular open source web platform commonly used to run dynamic we
     - APCu = `http://<your.IP>/apc.php`
     - OPcache = `http://<your.IP>/opcache.php`
 
-    **[MariaDB](./#mariadb) CLI:**
-
-    - As root user, run `mariadb` from command line, no separate authentication required. But note that this won't work via `sudo`, but an interactive root user shell session is required.
+    For database, check **[MariaDB](#mariadb)** details.
 
 === "Secured access - HTTPS/SSL"
 
@@ -211,17 +210,11 @@ LAMP stack is a popular open source web platform commonly used to run dynamic we
 
     - URL = `https://<your.IP>` or `https://<your.host.name>`
 
-=== "Official documentation"
-
-    - Apache HTTP Web Server - <https://httpd.apache.org/>
-    - MariaDB Server - <https://mariadb.org/>
-    - PHP - <https://www.php.net/>
-
 ### LASP Web Stack
 
-LASP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing SQLite instead of [MariaDB](./#mariadb).
+LASP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing [SQLite](#sqlite) instead of [MariaDB](#mariadb).
 
-SQLite is an embedded relational database engine. The documentation calls it _a self-contained, serverless, zero-configuration and transactional SQL database engine_. It is very popular and there are hundreds of millions copies worldwide in use today. Together with Apache2 and PHP could be a good candidate for single board computer.
+[SQLite](#sqlite) is an embedded relational database engine. It is popular and together with [Apache2](#apache2) and PHP could be a good candidate for single board computer.
 
 === "Quick start"
 
@@ -289,16 +282,10 @@ SQLite is an embedded relational database engine. The documentation calls it _a 
     Access website:
 
     - URL = `https://<your.IP>` or `https://<your.host.name>`
-
-=== "Official documentation"
-
-    - Apache HTTP Web Server - <https://httpd.apache.org/>
-    - SQLite Server - <https://sqlite.org/>
-    - PHP - <https://www.php.net/>
 
 ### LEMP Web Stack
 
-LEMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing Nginx instead of Apache2 web server.
+LEMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing [Nginx](#nginx) instead of [Apache2](#apache2) web server.
 
 **Nginx** is a popular choice, thanks to its lightweight utilization of resources and its flexibility to scale simply even with minimal equipment.
 
@@ -317,9 +304,7 @@ LEMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
     - APCu = `http://<your.IP>/apc.php`
     - OPcache = `http://<your.IP>/opcache.php`
 
-    **MariaDB CLI:**
-
-    - As root user, run `mariadb` from command line, no separate authentication required. But note that this won't work via `sudo`, but an interactive root user shell session is required.
+    For database, check **[MariaDB](#mariadb)** details.
 
 === "Secured access - HTTPS/SSL"
 
@@ -376,19 +361,11 @@ LEMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     - URL = `https://<your.IP>` or `https://<your.host.name>`
 
-=== "Official documentation"
-
-    - Nginx - <https://www.nginx.com/>
-    - MariaDB Server - <https://mariadb.org/>
-    - PHP - <https://www.php.net/>
-
 ### LESP Web Stack
 
-LESP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing Nginx instead of Apache2 web server, and SQLite instead of MariaDB.
+LESP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing [Nginx](#nginx) instead of [Apache2](#apache2) web server, and [SQLite](#sqlite) instead of MariaDB.
 
-**Nginx** is a popular choice, thanks to its lightweight utilization of resources and its flexibility to scale simply even with minimal equipment.
-
-**SQLite** implements a small, fast, self-contained, high-reliability SQL database engine, being one the most used database engine in the world ([see reference](https://sqlite.org/mostdeployed.html)).
+**[Nginx](#nginx)** is a popular choice, thanks to its lightweight utilization of resources and its flexibility to scale simply even with minimal equipment.
 
 === "Quick start"
 
@@ -408,18 +385,10 @@ LESP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
     Access website:
 
     - URL = `https://<your.IP>` or `https://<your.host.name>`
-
-=== "Official documentation"
-
-    - Nginx - <https://www.nginx.com/>
-    - SQLite Server - <https://sqlite.org/>
-    - PHP - <https://www.php.net/>
 
 ### LLMP Web Stack
 
-LLMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing Lighttpd instead of Apache2 web server.
-
-**Lighttpd** is designed and optimized for high performance environments. It comes with a small memory footprint compared to other web-servers and it provides an effective management of the CPU load.
+LLMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing [Lighttpd](#lighttpd) instead of [Apache2](#apache2) web server.
 
 === "Quick start"
 
@@ -437,9 +406,7 @@ LLMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
     - APCu = `http://<your.IP>/apc.php`
     - OPcache = `http://<your.IP>/opcache.php`
 
-    **[MariaDB](./#mariadb) CLI:**
-
-    - As root user, run `mariadb` from command line, no separate authentication required. But note that this won't work via `sudo`, but an interactive root user shell session is required.
+    For database, check **[MariaDB](#mariadb)** details.
 
 === "Secured access - HTTPS/SSL"
 
@@ -449,19 +416,9 @@ LLMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     - URL = `https://<your.IP>` or `https://<your.host.name>`
 
-=== "Official documentation"
-
-    - Lighttpd - <https://www.lighttpd.net/>
-    - MariaDB Server - <https://mariadb.org/>
-    - PHP - <https://www.php.net/>
-
 ### LLSP web stack
 
-LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing **Lighttpd** instead of Apache2 web server and **SQLite** instead of [MariaDB](./#mariadb).
-
-**Lighttpd** is designed and optimized for high performance environments. It comes with a small memory footprint compared to other web-servers and it provides an effective management of the CPU load.
-
-**SQLite** implements a small, fast, self-contained, high-reliability SQL database engine, being one the most used database engine in the world ([see reference](https://sqlite.org/mostdeployed.html)).
+LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing **[Lighttpd](#lighttpd)** instead of [Apache2](#apache2) web server and **[SQLite](#sqlite)** instead of [MariaDB](#mariadb).
 
 === "Quick start"
 
@@ -479,10 +436,8 @@ LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
     - APCu = `http://<your.IP>/apc.php`
     - OPcache = `http://<your.IP>/opcache.php`
 
-    **[MariaDB](./#mariadb) CLI:**
-
-    - As root user, run `mariadb` from command line, no separate authentication required. But note that this won't work via `sudo`, but an interactive root user shell session is required.
-
+    For database, check **[MariaDB](#mariadb)** details.
+    
 === "Secured access - HTTPS/SSL"
 
     **Let's Encrypt** is highly recommended - [see here how to install](../../dietpi_tools/#lets-encrypt-ssl-nordvpn-support). This will automate the creation and setup of your free SSL cert.
@@ -497,17 +452,11 @@ LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     - **Webserver**
 
-        Depending on your needs, you may choose the web server that fits best your needs. In case **Lighttpd** is not the right choice, you could continue with **Apache Web Server**, **Nginx** or **Tomcat webserver**.
+    Depending on your needs, you may choose the web server that fits best your needs. In case **[Lighttpd](#lighttpd)** is not the right choice, you could continue with **Apache Web Server**, **[Nginx](#nginx)** or **Tomcat webserver**.
 
     - Database
 
-        You may choose to install **[MariaDB](./#mariadb)** or other available databases like **InfluxDB**, **Redis**, **SQLite**.
-
-=== "Official documentation"
-
-    - Lighttpd - <https://www.lighttpd.net/>
-    - SQLite Server - <https://sqlite.org/>
-    - PHP - <https://www.php.net/>
+    You may choose to install **[MariaDB](#mariadb)** or other available databases like **[InfluxDB](#influxdb)**, **[Redis](#redis)**, **[SQLite](#sqlite)**.
 
 ## WebServers
 
@@ -521,6 +470,10 @@ Web servers are used to serve Web pages requested by client computers. Clients t
 
 Apache is a Apache Software Foundation project. The goal is to provide a secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards.
 
+=== "Official documentation"
+
+    - <https://httpd.apache.org/docs/>
+
 ### Nginx
 
 **Nginx** [engine x] is an HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server. It was released in 2004 to address the problem of increased web traffic. It has earned an excellent reputation and it is used in top million busiest sites - some of the success stories are: Dropbox, Netflix, Wordpress.com, FastMail.FM.[^1]
@@ -529,6 +482,9 @@ Apache is a Apache Software Foundation project. The goal is to provide a secure,
 
 The innovation of Nginx compared to earlier servers such as Apache was to use an asynchronous, event-driven architecture. Nginx is blazing fast, being extremely efficient when it comes to hardware utilization, allowing servers to get more speed out of their limited CPU and RAM. As a result, it is one of the fastest web server options for serving static content.
 
+=== "Official documentation"
+
+    - <https://www.nginx.com>
 ### Lighttpd
 
 **Lighttpd** is a web server for UNIX/Linux and Windows operating systems. It is an alternative to Apache web server. It is also called Lighty.
@@ -539,6 +495,13 @@ Source: Fair use, <https://en.wikipedia.org/w/index.php?curid=10881730>.
 
 It is designed to be secure, fast, standards-compliant, and flexible while being optimized for speed-critical environments. Its low memory footprint compared to other web servers, light CPU load and its speed goals make Lighttpd a perfect candidate for SBCs.
 
+=== "Quick access"
+
+    After the installation, check if Lighttpd service is running on `http://<your.IP>`.
+
+=== "Official documentation"
+
+    - <https://www.lighttpd.net>
 ### Tomcat
 
 What is **Apache Tomcat**? Essentially it’s an open-source Java servlet and Java Server Page container that lets developers implement an array of enterprise Java applications. Tomcat also runs a HTTP web server environment in which Java code can run.
@@ -546,6 +509,14 @@ What is **Apache Tomcat**? Essentially it’s an open-source Java servlet and Ja
 ![DietPi Webstack software Tomcat logo](../assets/images/dietpi-software-webstack-tomcat.svg){: style="width:100px"}
 
 Source: [The Apache Software Foundation](http://svn.apache.org/viewvc/jakarta/site/xdocs/images/logos/tomcat.eps), [Apache License 2.0](https://commons.wikimedia.org/w/index.php?curid=11302180).
+
+=== "Quick access"
+
+    After the installation, check if Tomcat service is running on `http://<your.IP>:8080`.
+
+=== "Official documentation"
+
+    - [Apache Tomcat website](http://tomcat.apache.org/index.html)
 
 ## Databases & Data stores
 
@@ -573,7 +544,7 @@ Source: [MariaDB](https://mariadb.com/), [LGPL](https://commons.wikimedia.org/w/
 
 ![DietPi Webstack software phpMyAdmin logo](../assets/images/dietpi-software-webstack-phpmyadmin.png){: style="width:150px"}
 
-**phpMyAdmin** is a free software tool written in PHP, intended to handle the administration of MySQL / MariaDB over the Web.
+**phpMyAdmin** is a free software tool written in [PHP](#php), intended to handle the administration of MySQL / MariaDB over the Web.
 
 Frequently used operations (_such as: managing databases, tables, columns, relations, indexes etc._) can be performed via the web user interface. Using the same application you could also directly execute any SQL statement.
 
@@ -594,6 +565,16 @@ Frequently used operations (_such as: managing databases, tables, columns, relat
 
 Source: Part of the SQLite documentation, which has been released by author D. Richard Hipp to the public domain. SVG conversion by Mike Toews. [Public Domain](https://commons.wikimedia.org/w/index.php?curid=11675072)
 
+**SQLite** is an embedded relational database engine. It it a self-contained,  high-reliability and full-featured SQL database engine. It is very popular and there are hundreds of millions copies worldwide in use today [^3].
+
+=== "Quick start"
+
+    To create a database and run commands, use the [quick start documentation](https://www.sqlite.org/quickstart.html).
+
+=== "Official documentation"
+
+    - [SQLite.org](https://www.sqlite.org/index.html)
+    - [SQLite.org documentation](https://www.sqlite.org/docs.html)
 ### Redis
 
 A non-SQL based data store.
@@ -606,9 +587,21 @@ Source: [Carlos Prioglio](http://redis.io/images/redis-logo.svg), [licence](http
 
 **Redis** is in the family of databases called key-value stores. The essence of a key-value store is the ability to store some data, called a value, inside a key. This data can later be retrieved only if we know the exact key used to store it.
 
+=== "Quick start"
+
+    The first thing to do in order to check Redis is working properly is sending a PING command using redis-cli:
+
+    ``` bash
+    redis-cli ping
+    ```
+
+    For more commands and an introduction to Redis data types and commands, read the [quick start documentation](https://redis.io/topics/data-types-intro).
+
 === "Official documentation"
 
-    <https://redis.io>
+    - Documentation: <https://redis.io/documentation>
+    - Commands: <https://redis.io/commands>
+    - Redis website: <https://redis.io>
 
 ### InfluxDB
 
@@ -718,5 +711,9 @@ Flask is a lightweight web application framework. It is designed to make getting
     Find out more about the success stories of Nginx on: <https://Nginx.org/en/>
 [^2]:
     ["Dead database walking: MySQL's creator on why the future belongs to MariaDB - MariaDB, open source, mysql, Oracle"](https://www2.computerworld.com.au/article/457551/dead_database_walking_mysql_creator_why_future_belongs_mariadb/). Computerworld. Retrieved 22 November 2020.
+[^3]:
+    [Most Widely Deployed and Used Database Engine](https://www.sqlite.org/mostdeployed.html). Retrieved 12 December 2020
+[^4]:
+    [NGINX vs. Apache: Our View of a Decade-Old Question](https://www.nginx.com/blog/nginx-vs-apache-our-view/). Retrieved 12 December 2020
 
 [Return to the **Optimised Software list**](../../dietpi_optimised_software)

--- a/docs/software/webserver_stack.md
+++ b/docs/software/webserver_stack.md
@@ -28,7 +28,8 @@
 
 [**Web development - Programming & Frameworks**](./#web-development-programming-frameworks)
 
-- [**PHP** - scripting language especially suited to web development](./#php)
+- [**Flask - Micro web framework powered by Python**](./#flask)
+- [**PHP** - Scripting language suited to web development](./#php)
 
 ??? info "How do I run **DietPi-Software** and install **optimised software** ?"
     To install any of the **DietPi optimised software** listed below run from the command line:
@@ -96,10 +97,10 @@ DietPi offers an **one-click-installation** of the following web development sta
 === "Which DATABASE to CHOOSE ?"
 
     **MariaDB**  
-    MariaDB is an open source RDBMS (relational data base management system). It is application compatible to MySQL, i.e. it can be used as a *drop in* replacement for MySQL. It has more features, fewer bugs, and a better performance compared to MySQL.
+    [MariaDB](./#mariadb) is an open source RDBMS (relational data base management system). It is application compatible to MySQL, i.e. it can be used as a *drop in* replacement for MySQL. It has more features, fewer bugs, and a better performance compared to MySQL.
 
     **SQLite**  
-    SQLite is an RDBMS, also compatible to MySQL. It offers a broader language support (i.e. more bindings to programming languages) compared to MariaDB. SQLite has a very small footprint. As drawbacks, it has no multi user capabilities and a couple of SQL features are missing.
+    SQLite is an RDBMS, also compatible to MySQL. It offers a broader language support (i.e. more bindings to programming languages) compared to [MariaDB](./#mariadb). SQLite has a very small footprint. As drawbacks, it has no multi user capabilities and a couple of SQL features are missing.
 
 ### How to install ?
 
@@ -124,7 +125,7 @@ The latter is used only in the case of the first webserver background installati
     ![DietPi webserver selection webserver preference](../assets/images/dietpi-software-webserver-preference.png){: style="width:500px"}
 
     Using this option you only select the webserver for use in DietPi installations.  
-    When you select any software for installation that requires a webserver (e.g. Pi-hole, Nextcloud, Webmin, installed via *Software Optimized*), DietPi will automatically install, configure and optimize your chosen webserver preference. DietPi will also install [MariaDB](https://wikipedia.org/wiki/MariaDB)/[SQLite](https://wikipedia.org/wiki/SQLite) as required, depending on your software selections. Basically, you will never need to manually select/install a webserver stack again. DietPi will do it all for you.
+    When you select any software for installation that requires a webserver (e.g. Pi-hole, Nextcloud, Webmin, installed via *Software Optimized*), DietPi will automatically install, configure and optimize your chosen webserver preference. DietPi will also install [MariaDB](./#mariadb) / [SQLite](https://wikipedia.org/wiki/SQLite) as required, depending on your software selections. Basically, you will never need to manually select/install a webserver stack again. DietPi will do it all for you.
 
     ???+ info "No webserver change if already installed"
         This setting "Webserver Preference* can NOT be changed if an existing webserver is installed on the system.
@@ -139,19 +140,19 @@ LAMP stack is a popular open source web platform commonly used to run dynamic we
 
     **Access website:**
 
-    - URL = `http://192.168.0.100` (`http://<your.local.ip>` or `http://<your.host.name>`)
+    - URL = `http://<your.IP>` or `http://<your.host.name>`
     - Local directory = `/var/www`
 
     **Access PHP info page:**
 
-    - URL = `http://192.168.0.100/phpinfo.php`
+    - URL = `http://<your.IP>/phpinfo.php`
 
     **Access memory cache info:**
 
-    - APCu = `http://192.168.0.100/apc.php`
-    - OPcache = `http://192.168.0.100/opcache.php`
+    - APCu = `http://<your.IP>/apc.php`
+    - OPcache = `http://<your.IP>/opcache.php`
 
-    **MariaDB CLI:**
+    **[MariaDB](./#mariadb) CLI:**
 
     - As root user, run `mariadb` from command line, no separate authentication required. But note that this won't work via `sudo`, but an interactive root user shell session is required.
 
@@ -208,7 +209,7 @@ LAMP stack is a popular open source web platform commonly used to run dynamic we
 
     Access website:
 
-    - URL = `https://192.168.0.100` (`https://<your.local.ip>` or `https://<your.host.name>`)
+    - URL = `https://<your.IP>` or `https://<your.host.name>`
 
 === "Official documentation"
 
@@ -218,7 +219,7 @@ LAMP stack is a popular open source web platform commonly used to run dynamic we
 
 ### LASP Web Stack
 
-LASP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing SQLite instead of MariaDB.
+LASP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing SQLite instead of [MariaDB](./#mariadb).
 
 SQLite is an embedded relational database engine. The documentation calls it _a self-contained, serverless, zero-configuration and transactional SQL database engine_. It is very popular and there are hundreds of millions copies worldwide in use today. Together with Apache2 and PHP could be a good candidate for single board computer.
 
@@ -226,13 +227,13 @@ SQLite is an embedded relational database engine. The documentation calls it _a 
 
     **Access website:**
 
-    - URL = `http://192.168.0.100` (`http://<your.local.ip>` or `http://<your.host.name>`)
+    - URL = `http://<your.IP>` or `http://<your.host.name>`
     - Local directory = `/var/www`
 
     **Access memory cache info:**
 
-    - APCu = `http://192.168.0.100/apc.php`
-    - OPcache = `http://192.168.0.100/opcache.php`
+    - APCu = `http://<your.IP>/apc.php`
+    - OPcache = `http://<your.IP>/opcache.php`
 
 === "Secured access - HTTPS/SSL"
 
@@ -287,7 +288,7 @@ SQLite is an embedded relational database engine. The documentation calls it _a 
 
     Access website:
 
-    - URL = `https://192.168.0.100` (`https://<your.local.ip>` or `https://<your.host.name>`)
+    - URL = `https://<your.IP>` or `https://<your.host.name>`
 
 === "Official documentation"
 
@@ -305,16 +306,16 @@ LEMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     **Access website:**
 
-    - URL = `http://192.168.0.100` (`http://<your.local.ip>` or `http://<your.host.name>`)
+    - URL = `http://<your.IP>` or `http://<your.host.name>`
 
     **Access PHP info page:**
 
-    - URL = `http://192.168.0.100/phpinfo.php`
+    - URL = `http://<your.IP>/phpinfo.php`
 
     **Access memory cache info:**
 
-    - APCu = `http://192.168.0.100/apc.php`
-    - OPcache = `http://192.168.0.100/opcache.php`
+    - APCu = `http://<your.IP>/apc.php`
+    - OPcache = `http://<your.IP>/opcache.php`
 
     **MariaDB CLI:**
 
@@ -373,7 +374,7 @@ LEMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     Access website:
 
-    - URL = `https://192.168.0.100` (`https://<your.local.ip>` or `https://<your.host.name>`)
+    - URL = `https://<your.IP>` or `https://<your.host.name>`
 
 === "Official documentation"
 
@@ -393,12 +394,12 @@ LESP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     **Access website:**
 
-    - URL = `http://192.168.0.100` (`http://<your.local.ip>` or `http://<your.host.name>`)
+    - URL = `http://<your.IP>` or `http://<your.host.name>`
 
     **Access memory cache info:**
 
-    - APCu = `http://192.168.0.100/apc.php`
-    - OPcache = `http://192.168.0.100/opcache.php`
+    - APCu = `http://<your.IP>/apc.php`
+    - OPcache = `http://<your.IP>/opcache.php`
 
 === "Secured access - HTTPS/SSL"
 
@@ -406,7 +407,7 @@ LESP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     Access website:
 
-    - URL = `https://192.168.0.100` (`https://<your.local.ip>` or `https://<your.host.name>`)
+    - URL = `https://<your.IP>` or `https://<your.host.name>`
 
 === "Official documentation"
 
@@ -424,19 +425,19 @@ LLMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     **Access website:**
 
-    - URL = `http://192.168.0.100` (`http://<your.local.ip>` or `http://<your.host.name>`)
+    - URL = `http://<your.IP>` or `http://<your.host.name>`
     - Local directory = `/var/www`
 
     **Access PHP info page:**
 
-    - URL = `http://192.168.0.100/phpinfo.php`
+    - URL = `http://<your.IP>/phpinfo.php`
 
     **Access memory cache info:**
 
-    - APCu = `http://192.168.0.100/apc.php`
-    - OPcache = `http://192.168.0.100/opcache.php`
+    - APCu = `http://<your.IP>/apc.php`
+    - OPcache = `http://<your.IP>/opcache.php`
 
-    **MariaDB CLI:**
+    **[MariaDB](./#mariadb) CLI:**
 
     - As root user, run `mariadb` from command line, no separate authentication required. But note that this won't work via `sudo`, but an interactive root user shell session is required.
 
@@ -446,7 +447,7 @@ LLMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     Access website:
 
-    - URL = `https://192.168.0.100` (`https://<your.local.ip>` or `https://<your.host.name>`)
+    - URL = `https://<your.IP>` or `https://<your.host.name>`
 
 === "Official documentation"
 
@@ -456,7 +457,7 @@ LLMP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
 ### LLSP web stack
 
-LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing **Lighttpd** instead of Apache2 web server and **SQLite** instead of MariaDB.
+LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack), providing **Lighttpd** instead of Apache2 web server and **SQLite** instead of [MariaDB](./#mariadb).
 
 **Lighttpd** is designed and optimized for high performance environments. It comes with a small memory footprint compared to other web-servers and it provides an effective management of the CPU load.
 
@@ -466,19 +467,19 @@ LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     **Access website:**
 
-    - URL = `http://192.168.0.100` (`http://<your.local.ip>` or `http://<your.host.name>`)
+    - URL = `http://<your.IP>` or `http://<your.host.name>`
     - Local directory = `/var/www`
 
     **Access PHP info page:**
 
-    - URL = `http://192.168.0.100/phpinfo.php`
+    - URL = `http://<your.IP>/phpinfo.php`
 
     **Access memory cache info:**
 
-    - APCu = `http://192.168.0.100/apc.php`
-    - OPcache = `http://192.168.0.100/opcache.php`
+    - APCu = `http://<your.IP>/apc.php`
+    - OPcache = `http://<your.IP>/opcache.php`
 
-    **MariaDB CLI:**
+    **[MariaDB](./#mariadb) CLI:**
 
     - As root user, run `mariadb` from command line, no separate authentication required. But note that this won't work via `sudo`, but an interactive root user shell session is required.
 
@@ -488,7 +489,7 @@ LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     Access website:
 
-    - URL = `https://192.168.0.100` (`https://<your.local.ip>` or `https://<your.host.name>`)
+    - URL = `https://<your.IP>` or `https://<your.host.name>`
 
 === "Individual installation"
 
@@ -500,7 +501,7 @@ LLSP is a variation of the popular open source [LAMP web stack](#lamp-web-stack)
 
     - Database
 
-        You may choose to install **MariaDB** or other available databases like **InfluxDB**, **Redis**, **SQLite**.
+        You may choose to install **[MariaDB](./#mariadb)** or other available databases like **InfluxDB**, **Redis**, **SQLite**.
 
 === "Official documentation"
 
@@ -556,17 +557,36 @@ Source: [The Apache Software Foundation](http://svn.apache.org/viewvc/jakarta/si
 
 Source: [MariaDB](https://mariadb.com/), [LGPL](https://commons.wikimedia.org/w/index.php?curid=55946550).
 
-#### phpMyAdmin
+=== "Quick access"
 
-Web interface SQL admin tool for webserver installations.
+    As `root` user, run `mariadb` from command line, no separate authentication required. But note that this won’t work via sudo, but an interactive root user shell session is required.
+
+    - username = `root`
+    - password = The same as your root login password, default is `dietpi`
+
+=== "Official documentation"
+
+    - [MariaDB website: mariadb.org](https://mariadb.org)
+    - [Getting started documentation](https://mariadb.org/documentation/#getting-started)  
+
+#### phpMyAdmin
 
 ![DietPi Webstack software phpMyAdmin logo](../assets/images/dietpi-software-webstack-phpmyadmin.png){: style="width:150px"}
 
-=== "Access to the web interface"
+**phpMyAdmin** is a free software tool written in PHP, intended to handle the administration of MySQL / MariaDB over the Web.
+
+Frequently used operations (_such as: managing databases, tables, columns, relations, indexes etc._) can be performed via the web user interface. Using the same application you could also directly execute any SQL statement.
+
+=== "Quick access"
 
     - URL = `http://<your.IP>/phpmyadmin`
     - Username = `phpmyadmin`
-    - Password = The same as your root login password. Default is `dietpi`
+    - Password = The same as your root login password, default is `dietpi`
+
+=== "Official documentation"
+
+    - [phpMyAdmin website](https://www.phpmyadmin.net)
+    - [phpMyAdmin documentation](https://www.phpmyadmin.net/docs/)  
 
 ### SQLite
 
@@ -576,11 +596,19 @@ Source: Part of the SQLite documentation, which has been released by author D. R
 
 ### Redis
 
-A non-SQL based (alternative) data store.
+A non-SQL based data store.
 
 ![DietPi Webstack software Redis logo](../assets/images/dietpi-software-webstack-redis.svg){: style="width:150px"}
 
 Source: [Carlos Prioglio](http://redis.io/images/redis-logo.svg), [licence](https://commons.wikimedia.org/w/index.php?curid=95020509).
+
+**Redis** is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker.
+
+**Redis** is in the family of databases called key-value stores. The essence of a key-value store is the ability to store some data, called a value, inside a key. This data can later be retrieved only if we know the exact key used to store it.
+
+=== "Official documentation"
+
+    <https://redis.io>
 
 ### InfluxDB
 
@@ -588,13 +616,103 @@ Source: [Carlos Prioglio](http://redis.io/images/redis-logo.svg), [licence](http
 
 Source: [InfluxData](https://influxdata.github.io/design.influxdata.com/branding-docs/img/influxdb/preview.svg), [Public Domain](https://commons.wikimedia.org/w/index.php?curid=55056027).
 
+**InfluxDB** is a _time series_ database designed to handle high write and query loads. InfluxDB is not only a time series platform, but it provides also an Web UI and dashboarding tools, background processing and monitoring agent.
+
+=== "Quick start"
+
+    After the installation, the data transfers are made via the http requests, and are handled directly by the InfluxDB service running on `http://<your.IP>:8086`.
+
+    - Create a database using `influxdb` via command line tool.
+      ``` bash
+      influx -execute 'create database myfirstdb'
+      ``` 
+
+    - Create a database using a HTTP request and `curl` tool:
+      ``` bash
+      curl -i -XPOST http://<your.IP>:8086/query --data-urlencode "q=CREATE DATABASE myfirstdb"
+      ```
+
+    - Post data
+      ``` bash
+      curl -i -XPOST 'http://<your.IP>:8086/write?db=myfirstdb' --data-binary 'temperature value=20.12'
+      ```
+    
+    - Retrieve and display data from the database
+    ``` bash
+    influx -database myfirstdb -execute 'SELECT * FROM temperature'
+    ```    
+
+=== "Users and security"
+
+    Create users and authorizations from influx CLI
+
+    ``` bash
+    influx -username admin -password admin01
+    ```
+
+    ``` bash
+    CREATE USER admin WITH PASSWORD 'admin01' WITH ALL PRIVILEGES
+    CREATE USER test_user WITH PASSWORD 'test_user01'
+    GRANT ALL ON mydb TO test_user  
+    exit
+    ```
+
+    !!! hint "How to enabled secured access (HTTPS)"
+        By default the _http_ authentication is disabled. To enable it, follow next two steps:
+
+        1. Change next setting in the configuration file `/etc/influxdb/influxdb.conf`:
+        ``` bash
+        auth-enabled = true
+        ```
+        2. Restart services
+        ``` bash
+        dietpi-services restart
+        ```
+
+=== "Official documentation"
+
+    - [InfluxDB Get Started](https://docs.influxdata.com/influxdb/v2.0/get-started/#set-up-influxdb)
+    - [InfluxDB website](https://www.influxdata.com/products/influxdb/)
+
+
 ## Web development - Programming & Frameworks
 
 ### PHP
 
-![DietPi Webstack software PHP logo](../assets/images/dietpi-software-webstack-php.svg){: style="width:150px"}
+![DietPi Webstack software PHP logo](../assets/images/dietpi-software-webstack-php.svg){: style="width:150px"} 
 
 Source: [Colin Viebrock](http://php.net/logos), [CC BY-SA 4.0](https://commons.wikimedia.org/w/index.php?curid=9632398).
+
+First introduced by Rasmus Lerdorf, PHP is an open-source, server-side general scripting language that has now become a de-facto coding standard in the web development industry. 
+
+=== "Quick start"
+
+    - There are many tutorials - here is the official [_Getting started_](https://www.php.net/manual/en/getting-started.php) from PHP documentation.
+
+=== "Official documentation"
+
+    - [PHP website](https://www.php.net)
+    - [PHP manual](https://www.php.net/manual/en/index.php)
+
+
+### Flask
+
+Flask is a lightweight web application framework. It is designed to make getting started quick and easy, with the ability to scale up to complex applications and it has become one of the most popular Python web application frameworks.
+
+=== "Quick start"
+
+    In order to use **Flask** it is first required first to install the Python Package Manager - [see Python Pip 3](../programming/#python). Then run the next command.
+
+    ``` bash
+    pip3 install -U Flask
+    ```
+
+=== "Official documentation"
+
+    - [User's guide & Documentation](https://flask.palletsprojects.com/en/1.1.x/)
+    - [Flask website](https://palletsprojects.com/p/flask/)
+    - [PyPi package page](https://pypi.org/project/Flask)
+    
 
 [^1]:
     Find out more about the success stories of Nginx on: <https://Nginx.org/en/>


### PR DESCRIPTION
Full extend the web development stacks, databases, and web servers section. It helps publishing the correct links on the DietPi website to the documentation (see PR https://github.com/MichaIng/DietPi-Website/issues/19).

Issue: https://github.com/MichaIng/DietPi-Docs/issues/237