### PR TITLE
mkdocs display fix (new file socialmedia.md added)

### DIFF
--- a/docs/socialmedia.md
+++ b/docs/socialmedia.md
@@ -6,10 +6,6 @@ date: 2021-02-08
 
 # Social media
 
-## DietPi Blog
-
-T.b.d.
-
 ## DietPi on Twitter
 
 DietPi announces are done via Twitter: <https://twitter.com/DietPi_>.

--- a/docs/socialmedia.md
+++ b/docs/socialmedia.md
@@ -1,0 +1,19 @@
+---
+title: socialmedia.md
+summary: Brief description of Blog platform, Twitter, Facebook, ...
+date: 2021-02-08  
+---
+
+# Social media
+
+## DietPi Blog
+
+T.b.d.
+
+## DietPi on Twitter
+
+DietPi announces are done via Twitter: <https://twitter.com/DietPi_>.
+
+## DietPi on Facebook
+
+DietPi announces and discussions are done via Facebook: <https://www.facebook.com/groups/167403007229675>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,9 @@ nav:
   - VPN: software/vpn.md
   - Web Development: software/webserver_stack.md
 - COMMUNITY:
+  # The first file "socialmedia.md" is added, otherwise in some browsers klicking on "Community" jumps directly to the first entry
+  # That was the case that a klick directly jumped to the github page. (Then you leave our genious dietpi.com/docs site...) :-)
+  - Social media: socialmedia.md
   - DietPi GitHub page: https://github.com/MichaIng/DietPi
   - Report issues: https://github.com/MichaIng/DietPi/issues
   - Request features: https://github.com/MichaIng/DietPi/issues/new/choose


### PR DESCRIPTION
I added a .md file as the first entry of the "Community" docs area.
Before there was the link to github.

Otherwise in some browsers klicking on "Community" jumps directly to the first entry.