### PR TITLE
Optimise image and YouTube loading

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -46,6 +46,7 @@ CactiChameleon
 CalDAV
 CardDAV
 CAVA
+CCleaner
 CDTV
 CedArctic
 Certbot
@@ -87,6 +88,7 @@ DIY
 DLNA
 DNS
 Domoticz
+DoT
 DPMS
 DRC
 DRM

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -166,7 +166,6 @@ Imgur
 InfluxData
 InfluxDB
 IoT
-IPs
 IPsec
 iptables
 IPv

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <h1 align="center"><img src="https://raw.githubusercontent.com/MichaIng/DietPi-Website/master/images/dietpi-logo_180x180.png" alt="DietPi Logo"></h1>
-
 <p align="center">
   <b>Lightweight justice for your single-board computer!</b>
   <br><br>
@@ -37,9 +36,9 @@ If you have experience with GitHub, you could either look for existent issue to 
 If you need help:
 
 - Send an email: micha@dietpi.com
-- Read the documentation: <https://dietpi.com/docs>
+- Read the documentation: <https://dietpi.com/docs/>
 
-To see the full list of possibilities, please check the [Contribution](https://dietpi.com/contribute.html) page.
+To see the full list of possibilities, please check our [contribution](https://dietpi.com/contribute.html) page.
 
 ## Feedback
 
@@ -58,6 +57,6 @@ To see the full list of possibilities, please check the [Contribution](https://d
 
 <a rel="cc:attributionURL" property="dct:title" href="https://dietpi.com/docs/">DietPi-Docs</a> by <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://dietpi.com/">DietPi</a> is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License - <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>.
 
-<a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/"><img src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>
+<a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/"><img src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"></a>
 
 This website shows logos of 3rd party software and providers which are excluded from the above license. They may only be used related to their product, for details, check individual trademark rules and licenses.

--- a/docs/dietpi_tools.md
+++ b/docs/dietpi_tools.md
@@ -55,7 +55,7 @@ It is one of the core tools, enabling you to install or uninstall one or more [*
 
     DietPi supports a large number of software titles. Instead of scrolling through the **Software Optimised** list to find a specific software title, you may use the **Search** option. Type in the software ID or any keyword form its title or description and you'll get a list filtered by matching results.
 
-    ![DietPi-Software Search menu screenshot](assets/images/dietpi-software-search.png){: loading="lazy"}
+    ![DietPi-Software Search menu screenshot](assets/images/dietpi-software-search.png){: with="752" height="321" loading="lazy"}
 
 ---
 

--- a/docs/dietpi_tools.md
+++ b/docs/dietpi_tools.md
@@ -8,7 +8,7 @@ It provides an easy access to all DietPi OS tools, and it could be accessed by r
 dietpi-launcher
 ```
 
-![DietPi-Launcher screenshot](assets/images/dietpi-launcher.jpg)
+![DietPi-Launcher screenshot](assets/images/dietpi-launcher.jpg){: width="642" height="366" loading="lazy"}
 
 ## DietPi software
 
@@ -20,7 +20,7 @@ dietpi-software
 
 It is one of the core tools, enabling you to install or uninstall one or more [**DietPi optimised software**](../software/) titles.
 
-![DietPi-Software screenshot](assets/images/dietpi-software.jpg)
+![DietPi-Software screenshot](assets/images/dietpi-software.jpg){: width="643" height="365" loading="lazy"}
 
 ### Software overview
 
@@ -40,7 +40,7 @@ It is one of the core tools, enabling you to install or uninstall one or more [*
 
     The software you selected will begin to install at this point. Once the process is completed, you may be asked to restart your device. Press **OK** to confirm.
 
-    ![DietPi-Software Software Optimised menu screenshot](assets/images/dietpi-software-optimised.jpg)
+    ![DietPi-Software Software Optimised menu screenshot](assets/images/dietpi-software-optimised.jpg){: width="643" height="365" loading="lazy"}
 
 === "Software Additional"
 
@@ -49,13 +49,13 @@ It is one of the core tools, enabling you to install or uninstall one or more [*
     - software packages that are often used and installed via `apt install <package>`, without additional optimisation from DietPi team.
     - _or_ packages not directly required, but pulled as a dependency, like: build tools, libraries or runtime systems. E.g. packages like *Python3*, *pip*, *tcpdump* or *midnight commander* can be installed using the dialog.
 
-    ![DietPi-Software Software Additional menu screenshot](assets/images/dietpi-software-additional.jpg){: width="640px"}
+    ![DietPi-Software Software Additional menu screenshot](assets/images/dietpi-software-additional.jpg){: width="640" height="485" loading="lazy"}
 
 === "Search"
 
     DietPi supports a large number of software titles. Instead of scrolling through the **Software Optimised** list to find a specific software title, you may use the **Search** option. Type in the software ID or any keyword form its title or description and you'll get a list filtered by matching results.
 
-    ![DietPi-Software Search menu screenshot](assets/images/dietpi-software-search.png)
+    ![DietPi-Software Search menu screenshot](assets/images/dietpi-software-search.png){: loading="lazy"}
 
 ---
 
@@ -65,7 +65,7 @@ It is one of the core tools, enabling you to install or uninstall one or more [*
 
     This lets you select your preferred SSH server. Also you can uninstall any SSH server to save memory and to exclude any external ssh based access.
 
-    ![DietPi-Software SSH Server menu screenshot](assets/images/dietpi-software-ssh-selection.jpg){: width="550px"}
+    ![DietPi-Software SSH Server menu screenshot](assets/images/dietpi-software-ssh-selection.jpg){: width="550" height="320" loading="lazy"}
 
 === "File Server"
 
@@ -82,7 +82,7 @@ It is one of the core tools, enabling you to install or uninstall one or more [*
     - ProFTPD can max out the RPi 100 Mbit connection with minimal CPU usage.
     - Samba server on a RPi v1 will hit 100% CPU usage at 40 Mbit transfer rate.
 
-    ![DietPi-Software File Server menu screenshot](assets/images/dietpi-software-fileserver-selection.jpg){: width="550px"}
+    ![DietPi-Software File Server menu screenshot](assets/images/dietpi-software-fileserver-selection.jpg){: width="550" height="342" loading="lazy"}
 
     See [file servers overview](../software/file_servers/) for further information.
 
@@ -93,7 +93,7 @@ It is one of the core tools, enabling you to install or uninstall one or more [*
 
     The Log System can be changed at any time by selecting a different “Log System” from the menu.
 
-    ![DietPi-Software Log System menu screenshot](assets/images/dietpi-software-log-system-selection.jpg){: width="550px"}
+    ![DietPi-Software Log System menu screenshot](assets/images/dietpi-software-log-system-selection.jpg){: width="550" height="370" loading="lazy"}
 
     See also <https://dietpi.com/docs/software/log_system/>.
 
@@ -107,7 +107,7 @@ It is one of the core tools, enabling you to install or uninstall one or more [*
 
         As a result you will not need to manually select/install a webserver stack. DietPi will do it all for you.
 
-    ![DietPi-Software Webserver Preference menu screenshot](assets/images/dietpi-software-webserver-preference.png){: width="550px"}
+    ![DietPi-Software Webserver Preference menu screenshot](assets/images/dietpi-software-webserver-preference.png){: width="550" height="340" loading="lazy"}
 
 === "User Data Location"
 
@@ -131,7 +131,7 @@ It is one of the core tools, enabling you to install or uninstall one or more [*
 
     DietPi will automatically move your existing user data to your new location.
 
-    ![DietPi-Software User Data Location menu screenshot](assets/images/dietpi-software-user-data-location-selection.jpg){: width="550px"}
+    ![DietPi-Software User Data Location menu screenshot](assets/images/dietpi-software-user-data-location-selection.jpg){: width="550" height="287" loading="lazy"}
 
 ---
 
@@ -163,7 +163,7 @@ It is one of the core tools, enabling you to install or uninstall one or more [*
 
     The <software_id\> which has to be given is the one which is present in the software list within the `dietpi-software` dialogues:
 
-    ![DietPi-Tools command line installation](assets/images/dietpi-tools-command-line-installation.png){: width="400px"}
+    ![DietPi-Tools command line installation](assets/images/dietpi-tools-command-line-installation.png){: width="454" height="129" loading="lazy"}
 
     E.g. to install Chromium, LXQt and GIMP you have to execute:
 
@@ -180,11 +180,11 @@ Run `dietpi-letsencrypt`.
 
 In case of a non installed Certbot package it is installed at first:
 
-![DietPi-LetsEncrypt screenshot](assets/images/dietpi-letsencrypt.jpg)
+![DietPi-LetsEncrypt screenshot](assets/images/dietpi-letsencrypt.jpg){: width="642" height="216" loading="lazy"}
 
 In the installation dialog some entries have to be made which are needed for the certificate (domain, Email), the other entries are configuration options. It is recommended to leave the key size at 4096 bits.
 
-![DietPi-LetsEncrypt configuration screenshot](assets/images/dietpi-letsencrypt_2.png){: width="640px"}
+![DietPi-LetsEncrypt configuration screenshot](assets/images/dietpi-letsencrypt_2.png){: width="642" height="279" loading="lazy"}
 
 When you execute the certificate installation it also installs it for your selected web server, i.e. you do not have to edit your web server configuration files, the installation routine does all for you.
 
@@ -196,7 +196,7 @@ When you execute the certificate installation it also installs it for your selec
 
 Run `dietpi-nordvpn`.
 
-![DietPi-NordVPN screenshot](assets/images/dietpi-nordvpn.jpg)
+![DietPi-NordVPN screenshot](assets/images/dietpi-nordvpn.jpg){: width="642" height="207" loading="lazy"}
 
 ## System configuration
 
@@ -205,7 +205,7 @@ Run `dietpi-nordvpn`.
 Configure various system settings, from display / audio / network to _auto start_ options.  
 Run `dietpi-config`.
 
-![DietPi-Config screenshot](assets/images/dietpi-config.jpg)
+![DietPi-Config screenshot](assets/images/dietpi-config.jpg){: width="643" height="335" loading="lazy"}
 
 === "Display Options"
 
@@ -298,7 +298,7 @@ Feature-rich drive management utility. It is a lightweight program that allows y
 
 Run `dietpi-drive_manager`.
 
-![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager.jpg)
+![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager.jpg){: width="643" height="327" loading="lazy"}
 
 === "Setup a dedicated drive for DietPi"
 
@@ -309,14 +309,14 @@ Run `dietpi-drive_manager`.
     1. Select `Refresh` from the menu (if it doesn't show up straight away, give it a few seconds for system to update, then try again).
     1. Select the drive you wish to use from the list, then press ++enter++.
 
-        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_2.png){: width="600px"}
+        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_2.png){: width="600" height="297" loading="lazy"}
 
         If needed, format the drive before usage selecting the `Format` option (file system type description see below).  
         Remark: Formatting drives can only be done unmounted.
 
         If needed, mount the drive via the `Mount` selection. If mounted, commands `Unmount`, `Benchmark`, `User data`, `Swapfile` and `Read only` are present.
 
-        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_3.png){: width="600px"}
+        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_3.png){: width="600" height="395" loading="lazy"}
 
 === "Move the location of user data and swap file"
 
@@ -330,18 +330,18 @@ Run `dietpi-drive_manager`.
 
         - Move user data:
 
-        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_4.png){: width="500px"}
+        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_4.png){: width="500" height="139" loading="lazy"}
 
         - Change swap file size:
 
-        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_5.png){: width="500px"}
+        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_5.png){: width="500" height="188" loading="lazy"}
 
 === "Format file system types"
 
     Formatting file systems lead you to these dialogues:
 
-    ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_6.png){: width="500px"}
-    ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_7.png){: width="500px"}
+    ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_6.png){: width="500" height="137" loading="lazy"}
+    ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_7.png){: width="500" height="326" loading="lazy"}
 
     In the latter dialog you have to choose the file system type. The following selections may be chosen:
 
@@ -393,7 +393,7 @@ Run `dietpi-drive_manager`.
     1. Select the disk containing the root (`/`) partition and press ++enter++.
     1. Select `Resize` and press ++enter++.
 
-        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_8.png){: width="500px"}
+        ![DietPi-Drive_Manager screenshot](assets/images/dietpi-drive-manager_8.png){: width="500" height="138" loading="lazy"}
 
     1. Reboot your system to expand the root file system to use the whole space of the new memory card.
 
@@ -406,7 +406,7 @@ Run `dietpi-drive_manager`.
 Defines software packages to start when the DietPi OS boots up. Example, boot into the desktop with Kodi running.  
 Run `dietpi-autostart`.
 
-![DietPi-Autostart screenshot](assets/images/dietpi-autostart.jpg)
+![DietPi-Autostart screenshot](assets/images/dietpi-autostart.jpg){: width="644" height="368" loading="lazy"}
 
 !!! info "Autostart option in `dietpi.txt` (first initial boot)"
     When booting the DietPi system the first time, the autostart option can also be set via the file `dietpi.txt`. See option  
@@ -419,11 +419,11 @@ Run `dietpi-autostart`.
 Provides service control, priority level tweaks and status print.  
 Run `dietpi-services`.
 
-![DietPi-Services screenshot](assets/images/dietpi-services.jpg)
+![DietPi-Services screenshot](assets/images/dietpi-services.jpg){: width="644" height="341" loading="lazy"}
 
 The dialog to tweak a service is entered by highlighting the service (keys ++arrow-up++ and ++arrow-down++) and pressing ++enter++. The configuration dialog (example: cron service) looks like this:
 
-![DietPi-Services tweaking screenshot](assets/images/dietpi-services_2.png){: width="640px"}
+![DietPi-Services tweaking screenshot](assets/images/dietpi-services_2.png){: width="644" height="461" loading="lazy"}
 
 !!! caution "Be careful at tweaking the services."
 
@@ -432,7 +432,7 @@ The dialog to tweak a service is entered by highlighting the service (keys ++arr
 Change triggers for the status LEDs on your SBC/motherboard.  
 Run `dietpi-led_control`.
 
-![DietPi-LED_control screenshot](assets/images/dietpi-ledcontrol.jpg)
+![DietPi-LED_control screenshot](assets/images/dietpi-ledcontrol.jpg){: width="643" height="269" loading="lazy"}
 
 Depending on your used hardware, the number of entries in the dialog will change.
 
@@ -441,7 +441,7 @@ Depending on your used hardware, the number of entries in the dialog will change
 Modify the start times of specific cron job groups.  
 Run `dietpi-cron`.
 
-![DietPi-Cron screenshot](assets/images/dietpi-cron.jpg)
+![DietPi-Cron screenshot](assets/images/dietpi-cron.jpg){: width="643" height="357" loading="lazy"}
 
 ### DietPi JustBoom
 
@@ -450,11 +450,11 @@ Run `dietpi-justboom`.
 
 If the sound output is configured, the following dialog appears:
 
-![DietPi-JustBoom screenshot](assets/images/dietpi-justboom_2.jpg)
+![DietPi-JustBoom screenshot](assets/images/dietpi-justboom_2.jpg){: width="642" height="223" loading="lazy"}
 
 If no sound output is configured, the following dialog appears:
 
-![DietPi-JustBoom screenshot](assets/images/dietpi-justboom.jpg)
+![DietPi-JustBoom screenshot](assets/images/dietpi-justboom.jpg){: width="642" height="228" loading="lazy"}
 
 In this case you have to e.g. install a sound program package via `dietpi-software` or configure the sound output e.g. via `dietpi-config`.
 
@@ -476,7 +476,7 @@ DietPi Survey allows the DietPi project to obtain general information regarding 
 
     **In short words:** By selecting ***Opt IN***, you are supporting the DietPi project with no impact to your system or private data.
 
-![DietPi Survey screenshot](assets/images/dietpi-survey.jpg)
+![DietPi Survey screenshot](assets/images/dietpi-survey.jpg){: width="645" height="368" loading="lazy"}
 
 === "Data transmission events"
 
@@ -564,7 +564,7 @@ Clean up not necessary files from the operating system and free up valuable disk
 Think of it as lightweight CCleaner for DietPi and Linux.  
 Run `dietpi-cleaner`.
 
-![DietPi-Cleaner screenshot](assets/images/dietpi-cleaner.jpg)
+![DietPi-Cleaner screenshot](assets/images/dietpi-cleaner.jpg){: width="644" height="284" loading="lazy"}
 
 By simulating the cleaner process (via menu entry `Test`) you get a preview of the deletions the cleaner does before you start the cleaning process (via menu entry `Run`).
 
@@ -572,20 +572,20 @@ By simulating the cleaner process (via menu entry `Test`) you get a preview of t
 
 DietPi-Cleaner uses modules which you can be switched on or off before running the cleaning process. Select them via the main menue entry `Cleaners`.
 
-![DietPi-Cleaner types screenshot](assets/images/dietpi-cleaner_2.png){: width="640px"}
+![DietPi-Cleaner types screenshot](assets/images/dietpi-cleaner_2.png){: width="644" height="242" loading="lazy"}
 
 #### Files cleaner
 
 The files cleaner allows you to customize a list of filenames to search and remove, during the cleaning process. Select them via the main menue entry `Files`.
 
-![DietPi-Cleaner types screenshot](assets/images/dietpi-cleaner_3.png){: width="640px"}
+![DietPi-Cleaner types screenshot](assets/images/dietpi-cleaner_3.png){: width="644" height="388" loading="lazy"}
 
 ### DietPi log clear
 
 Clear log files in `/var/log/`.  
 Run `dietpi-logclear`.
 
-![DietPi-LogClear screenshot](assets/images/dietpi-logclear.jpg)
+![DietPi-LogClear screenshot](assets/images/dietpi-logclear.jpg){: width="643" height="198" loading="lazy"}
 
 ### DietPi backup (backup/restore)
 
@@ -596,7 +596,7 @@ You can also customize which files/folders are included and excluded through the
 If you have *broken* your system, or want to reset your system to an earlier date, this can all be done with `DietPi-Backup`. Just make sure you create a backup first.  
 Run `dietpi-backup`.
 
-![DietPi-Backup screenshot](assets/images/dietpi-backup_1.png)
+![DietPi-Backup screenshot](assets/images/dietpi-backup_1.png){: width="643" height="298" loading="lazy"}
 
 Remark: In the case that `rsync` is not installed, it is installed.
 
@@ -607,14 +607,14 @@ Remark: In the case that `rsync` is not installed, it is installed.
 Lightweight file manager and explorer.  
 Run `dietpi-explorer`.
 
-![DietPi-Explorer screenshot](assets/images/dietpi-explorer.jpg)
+![DietPi-Explorer screenshot](assets/images/dietpi-explorer.jpg){: width="646" height="355" loading="lazy"}
 
 ### DietPi sync
 
 DietPi-Sync allows you to duplicate a directory from one location (*Source Location*) to another (*Target Location*).  
 Run `dietpi-sync`.
 
-![DietPi-Sync screenshot](assets/images/dietpi-sync.jpg)
+![DietPi-Sync screenshot](assets/images/dietpi-sync.jpg){: width="646" height="322" loading="lazy"}
 
 Example: If you want to duplicate (sync) the data on your external USB HDD to another location, you simply select the USB HDD as the source, then, select a target location. The target location can be anything from a networked samba file server, or even an FTP server.  
 Each sync includes a leading dry run, after which you can check the expected result before deciding if you want to continue with the actual sync.
@@ -643,7 +643,7 @@ The following commands are non-interactive, but error-handled wrappers for `apt-
 Displays CPU temperature, processor frequency, throttle level etc.  
 Run `cpu`.
 
-![DietPi-CPU_info screenshot](assets/images/dietpi-tools-cpuinfo.png)
+![DietPi-CPU_info screenshot](assets/images/dietpi-tools-cpuinfo.png){: width="741" height="299" loading="lazy"}
 
 ### DietPi morse code
 
@@ -654,4 +654,4 @@ Run `dietpi-morsecode`.
 
 Run `dietpi-bugreport`.
 
-![DietPi-Bugreport screenshot](assets/images/dietpi-bugreport.jpg)
+![DietPi-Bugreport screenshot](assets/images/dietpi-bugreport.jpg){: width="646" height="352" loading="lazy"}

--- a/docs/dietpi_tools.md
+++ b/docs/dietpi_tools.md
@@ -570,13 +570,13 @@ By simulating the cleaner process (via menu entry `Test`) you get a preview of t
 
 #### Cleaner Types
 
-DietPi-Cleaner uses modules which you can be switched on or off before running the cleaning process. Select them via the main menue entry `Cleaners`.
+DietPi-Cleaner uses modules which you can be switched on or off before running the cleaning process. Select them via the main menu entry `Cleaners`.
 
 ![DietPi-Cleaner types screenshot](assets/images/dietpi-cleaner_2.png){: width="644" height="242" loading="lazy"}
 
 #### Files cleaner
 
-The files cleaner allows you to customize a list of filenames to search and remove, during the cleaning process. Select them via the main menue entry `Files`.
+The files cleaner allows you to customize a list of filenames to search and remove, during the cleaning process. Select them via the main menu entry `Files`.
 
 ![DietPi-Cleaner types screenshot](assets/images/dietpi-cleaner_3.png){: width="644" height="388" loading="lazy"}
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,13 +8,13 @@ Once you did the [DietPi Installation](../install/) you could choose to install 
 
 This will be the first screen displayed.
 
-![dietpi-login-screen](assets/images/dietpi-login-screen.jpg)
+![dietpi-login-screen](assets/images/dietpi-login-screen.jpg){: width="644" height="361" loading="lazy"}
 
 ## DietPi-Launcher
 
 Once you run `dietpi-launcher` you could see all available DietPi tools. It provides a quick way to run any the DietPi tools: from installing **DietPi Optimised software** to simple configure your device, from enabling services to start to backup your installation and so on.
 
-![DietPi-Launcher screenshot](assets/images/dietpi-launcher.jpg).
+![DietPi-Launcher screenshot](assets/images/dietpi-launcher.jpg){: width="642" height="366" loading="lazy"}
 
 ## DietPi-Software -- Choose the software you need
 
@@ -40,7 +40,7 @@ The list of optimised software includes:
 
 To install and configure them use `dietpi-software` tool - [click for more details](../dietpi_tools/#dietpi-software).
 
-![DietPi-Software screenshot](assets/images/dietpi-software.jpg)
+![DietPi-Software screenshot](assets/images/dietpi-software.jpg){: width="643" height="365" loading="lazy"}
 
 ## Supported SBC
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -29,7 +29,7 @@ and even on the compact form **Raspberry Pi Zero W**
 
 Quick intro:
 
-<iframe src="https://www.youtube-nocookie.com/embed/sajBySPeYH0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+<iframe src="https://www.youtube-nocookie.com/embed/sajBySPeYH0?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
 
 <div class="md-typeset__table">
     <table>

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -17,7 +17,7 @@ DietPi runs on the full range of Raspberry Pi boards and computers. This include
 
 or the most recent **Raspberry Pi 4 Model B** boards, launched in 2019, as well as in 2020.
 
-![Raspberry Pi 4 Model B photo](assets/images/dietpi-raspberry-pi-400-back.jpg){: width="500" height="292" loading="lazy"}
+![Raspberry Pi 4 Model B photo](assets/images/raspberry-pi-4-labelled.png){: width="500" height="292" loading="lazy"}
 
 DietPi runs also on one of the first models **Raspberry Pi 1**, launched in 2012
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -13,23 +13,23 @@ You can install DietPi by following the step by step [Starting guide](../install
 
 DietPi runs on the full range of Raspberry Pi boards and computers. This includes the newly launched [Raspberry Pi 400](https://www.raspberrypi.org/products/raspberry-pi-400/?resellerType=home),
 
-![DietPi Raspberry Pi 400](./assets/images/dietpi-raspberry-pi-400-back.jpg)
+![Raspberry Pi 400 photo](assets/images/dietpi-raspberry-pi-400-back.jpg){: width="800" height="571" loading="lazy"}
 
 or the most recent **Raspberry Pi 4 Model B** boards, launched in 2019, as well as in 2020.
 
-<img src="../assets/images/raspberry-pi-4-labelled.png" title="Raspberry Pi model 4B" width="500" />
+![Raspberry Pi 4 Model B photo](assets/images/dietpi-raspberry-pi-400-back.jpg){: width="500" height="292" loading="lazy"}
 
 DietPi runs also on one of the first models **Raspberry Pi 1**, launched in 2012
 
-<img src="../assets/images/raspberry-pi-1b.jpg" title="Raspberry Pi model 1B" width="500" />
+![Raspberry Pi 1 Model B photo](assets/images/raspberry-pi-1b.jpg){: width="500" height="242" loading="lazy"}
 
 and even on the compact form **Raspberry Pi Zero W**
 
-<img src="../assets/images/raspberry-pi-zero-w.jpg" title="Raspberry Pi zero W" width="500" />
+![Raspberry Pi Zero W photo](assets/images/raspberry-pi-zero-w.jpg){: width="500" height="333" loading="lazy"}
 
 Quick intro:
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/sajBySPeYH0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope" allowfullscreen></iframe>
+<iframe src="https://www.youtube-nocookie.com/embed/sajBySPeYH0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
 
 <div class="md-typeset__table">
     <table>
@@ -66,7 +66,7 @@ ODROID single board computers are powerful, stable, and fast performing. They ca
 
 ODROID-N2 is one of the supported boards.
 
-<img src="../assets/images/dietpi-odroid-n2-plus.jpg" title="Odroid N2+" width="500" />
+![Odroid N2 photo](assets/images/dietpi-odroid-n2-plus.jpg){: width="500" height="353" loading="lazy"}
 
 It is a new generation single board computer that is more powerful, more stable, and faster performing than N1. The main CPU of the N2 is based on big. Thanks to the modern 12nm silicon technology, the A73 cores runs at 1.8 GHz without thermal throttling using the stock metal-housing heat sink allowing a robust and quiet computer.
 
@@ -119,7 +119,7 @@ This is where PINE64 journey began. The PINE A64 is their first Single Board Com
 
 The ROCKPro64 is the most powerful single board computer offered by PINE64.
 
-<img src="../assets/images/dietpi-rockpro64.jpg" title="PINE64 ROCKPro64" width="500" />
+![PINE64 ROCKPro64 photo](assets/images/dietpi-rockpro64.jpg){: width="500" height="375" loading="lazy"}
 
 It features a Rockchip RK3399 hexa-core SOC and up-to 4 GiB of dual-channel LPDDR4 system memory. Moreover, the board comes packed with features, including: an USB 3.0 and USB type C with DP1.2 port, a full PCIe x4 as well as eMMC module socket. You also get a 40pin header with I2C, SPI, UART and GPIO.
 
@@ -177,7 +177,7 @@ For more details visit the [**Radxa ROCK Pi**](https://rockpi.org/) website.
 
 One of the supported boards is ROCK Pi 4.
 
-<img src="../assets/images/dietpi-rockpi-4b.jpg" title="Radxa ROCK Pi 4B" width="500" />
+![Radxa ROCK Pi 4 photo](assets/images/dietpi-rockpi-4b.jpg){: width="500" height="375" loading="lazy"}
 
 ROCK Pi 4 is a Single Board Computer (SBC) in an ultra-small form factor that offers class-leading performance while leveraging outstanding mechanical compatibility. The ROCK Pi 4 offers makers, IoT enthusiasts, hobbyists, PC DIY enthusiasts and others a reliable and extremely capable platform for building and tinkering their ideas into reality.
 
@@ -210,7 +210,7 @@ ROCK Pi 4 is a Single Board Computer (SBC) in an ultra-small form factor that of
 
 **Six-core 64-bit High Performance Open Source Platform**. For more details visit [**Firefly RK3399**](https://en.t-firefly.com/product/rk3399.html) website.
 
-<img src="../assets/images/dietpi-firefly-rk3399.png" title="Firefly RK3399" width="500" />
+![Firefly RK3399 photo](assets/images/dietpi-firefly-rk3399.png){: width="413" height="331" loading="lazy"}
 
 <div class="md-typeset__table">
     <table>
@@ -235,7 +235,7 @@ ROCK Pi 4 is a Single Board Computer (SBC) in an ultra-small form factor that of
 
 Sparky Single Board Computer (SBC) is a credit card-sized board that can be used as a standalone computer, in electronics projects, games, and also in many other applications. A true open hardware, community-supported embedded computer for developers and hobbyists. The Sparky SBC has all the functionality of a basic computer. For more details visit the [**Allo Sparky SBC**](https://www.allo.com/sparky/sparky-sbc.html) website.
 
-<img src="../assets/images/dietpi-sparky-sbc.jpg" title="Sparky SBC" width="500" />
+![Allo Sparky SBC photo](assets/images/dietpi-sparky-sbc.jpg){: width="500" height="412" loading="lazy"}
 
 <div class="md-typeset__table">
     <table>
@@ -262,7 +262,7 @@ Tinker Board is a Single Board Computer (SBC) in an ultra-small form factor that
 
 Tinker Board features standard maker connectivity options, including a 40-pin GPIO interface that allow for interfacing with a range inputs from buttons, switches, sensors, LEDs, and much more.
 
-<img src="../assets/images/dietpi-tinkerboard.jpg" title="ASUS Tinker Board" width="500" />
+![ASUS Tinker Board photo](assets/images/dietpi-tinkerboard.jpg){: width="500" height="353" loading="lazy"}
 
 Tinker Board is equipped with one DSI MIPI connection for displays and touchscreens. The secondary CSI MIPI connection is for connection to compatible cameras allowing for computer vision, and much more.
 
@@ -293,7 +293,7 @@ Careful consideration went into the design and development of the Tinker Board t
 
 For more details visit the [**FriendlyARM**](https://www.friendlyarm.com/) website.
 
-<img src="../assets/images/dietpi-nanopi-k2.jpg" title="FriendlyARM NanoPi K2" width="500" />
+![FriendlyARM NanoPi K2 photo](assets/images/dietpi-nanopi-k2.jpg){: width="500" height="350" loading="lazy"}
 
 **NanoPi K2** supports DVFS and it can smooth play high-definition video streams, and it is very well suited for applications such as advertisement machines, TV boxes, home entertainment appliances or multimedia devices.
 
@@ -430,7 +430,7 @@ The VMware virtual machine is great for those occasions where SBC performance ju
 
 ### VirtualBox
 
-![Oracle VirtualBox](assets/images/vbox.jpg)
+![Oracle VirtualBox logo](assets/images/vbox.jpg){: width="267" height="273" loading="lazy"}
 
 VirtualBox is a general-purpose full virtualiser for x86 hardware, targeted at server, desktop and embedded use.
 
@@ -573,22 +573,22 @@ chmod +x PREP_SYSTEM_FOR_DIETPI.sh
 
 In the following dialog you have to select the DietPi installer branch. Choose the same branch as the DietPi `PREP_SYSTEM_FOR_DIETPI.sh` script:
 
-![DietPi-PREP branch selection](assets/images/dietpi-prep-selectbranch.png){: width="550px"}
+![DietPi-PREP branch selection](assets/images/dietpi-prep-selectbranch.png){: width="550" height="266" loading="lazy"}
 
 In the following dialogues enter your name and afterwards the actual image base and the device (SBC or PC) the system is running on:
 
-![DietPi-PREP pre-image entry](assets/images/dietpi-prep-preimage.png){: width="550px"}
+![DietPi-PREP pre-image entry](assets/images/dietpi-prep-preimage.png){: width="550" height="218" loading="lazy"}
 
-![DietPi-PREP device selection](assets/images/dietpi-prep-deviceselection.png){: width="550px"}
+![DietPi-PREP device selection](assets/images/dietpi-prep-deviceselection.png){: width="550" height="290" loading="lazy"}
 
 Depending on whether you want to use the WiFi feature later on, you have to select the option to keep or purge the WiFi package. To keep the package could be the case if your hardware has an onboard WiFi or you add the WiFi e.g. via an USB WiFi adapter.
 
-![DietPi-PREP WiFi selection](assets/images/dietpi-prep-wifiselection.png){: width="550px"}
+![DietPi-PREP WiFi selection](assets/images/dietpi-prep-wifiselection.png){: width="550" height="184" loading="lazy"}
 
 The last selection is the target Debian version (the actual **Buster** or the upcoming **Bullseye**).  
 After this, the script runs a couple of minutes, finally the following message occurs:
 
-![DietPi-PREP finish output](assets/images/dietpi-prep-finish.png){: width="550px"}
+![DietPi-PREP finish output](assets/images/dietpi-prep-finish.png){: width="550" height="113" loading="lazy"}
 
 If you did not use branch `master` the last step is to edit file `/boot/dietpi.txt` and edit the  
 `DEV_GITBRANCH=master`  

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ description: How to install DietPi on SBCs and virtualized environments. Install
 title: DietPi Documentation
 ---
 
-[![DietPi Logo](https://dietpi.com/images/dietpi-logo_180x180.png)](https://dietpi.com/)
+[![DietPi Logo](https://dietpi.com/images/dietpi-logo_180x180.png){: width="180" height="180" loading="lazy"}](https://dietpi.com/)
 
 #### DietPi | Minimal image at its core
 
@@ -56,8 +56,9 @@ Check [_Supported SBCs_](hardware/) page for recently supported list.
 
 ## Community
 
-Have some feedback, questions, suggestions, or just fancy a chat ? Visit our [community](https://dietpi.com/phpbb/) !
-![DietPi Forum](assets/images/dietpi-forum.jpg)
+Have some feedback, questions, suggestions, or just fancy a chat ? Visit our [community](https://dietpi.com/phpbb/)!
+
+![DietPi Forum](assets/images/dietpi-forum.jpg){: width="1024" height="530" loading="lazy"}
 
 ## Collaborate on the project
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ Select the following tabs for the installation description of your target.
 
     Single board computers (SBCs) based on the well known Raspberry PI ARM based architecture gained more and more friends in the last years. The low cost in combination with the power and hardware flexibility makes these SBCs optimal for embedded systems, like e.g. home automation or cloud applications.
 
-    ![raspberry-pi-1-model-b](assets/images/raspberry-pi-1b.jpg)
+    ![Raspberry Pi 1 Model B photo](assets/images/raspberry-pi-1b.jpg){: width="598" height="289" loading="lazy"}
 
     ## Prerequisites
 
@@ -38,7 +38,7 @@ Select the following tabs for the installation description of your target.
     Open [`dietpi.com`](https://dietpi.com/#download) and select “Download”. Various supported devices will be displayed. Choose the preferred SBC and click on the **Download**. The disk image will be downloaded locally.
 
     _Example:_
-    ![DietPi for Raspberry Pi download page](assets/images/DietPi-RaspberryPi-image.jpg)
+    ![DietPi for Raspberry Pi download page](assets/images/DietPi-RaspberryPi-image.jpg){: width="1186" height="561" loading="lazy"}
 
     **Unzip the downloaded file to a local folder.**
 
@@ -68,7 +68,7 @@ Select the following tabs for the installation description of your target.
 
     Start balenaEtcher and make sure you have your SD card inserted into your computer. Locate and select the DietPi image.
 
-    ![DietPi-Etcher-install-01](assets/images/DietPi-Etcher-install-01.jpg)
+    ![DietPi-Etcher-install-01](assets/images/DietPi-Etcher-install-01.jpg){: width="795" height="529" loading="lazy"}
 
     Next, ensure that the SD card selected is the correct one.
 
@@ -76,11 +76,11 @@ Select the following tabs for the installation description of your target.
         The flash procedure will wipe the drive clean, so if you choose the wrong one, you may risk losing data.
 
 
-    ![DietPi-Etcher-install-02](assets/images/DietPi-Etcher-install-02.jpg)
+    ![DietPi-Etcher-install-02](assets/images/DietPi-Etcher-install-02.jpg){: width="796" height="478" loading="lazy"}
 
     Once you have confirmed all the details are correct, proceed to flash the SD card. This process may take a while.
 
-    ![DietPi-Etcher-install-03](assets/images/DietPi-Etcher-install-03.jpg)
+    ![DietPi-Etcher-install-03](assets/images/DietPi-Etcher-install-03.jpg){: width="796" height="478" loading="lazy"}
 
     ??? info "Click here if you want to pre-configure WiFi network "
         To setup the WiFi, open the SD card folder, and update next two files using a text editor of your choice:
@@ -104,7 +104,7 @@ Select the following tabs for the installation description of your target.
 
     The Native PC images are great for those occasions where SBC performance is just not enough. One example could be [Intel NUC Kit](https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits.html?page=2). It is a small, versatile, upgradable, and affordable desktop PC with the same basic feature set as that of a much larger machine.
 
-    ![DietPi-Intel-NUC](assets/images/dietpi-nuc8.jpg)
+    ![DietPi-Intel-NUC](assets/images/dietpi-nuc8.jpg){: width="825" height="550" loading="lazy"}
 
     It could be also a great way to make use of an old computer that’s not capable of running the latest version of Windows or macOS.
 
@@ -122,7 +122,7 @@ Select the following tabs for the installation description of your target.
     Download the **DietPi installer image** from [`dietpi.com`](https://dietpi.com/#download) and
     unzip the downloaded file to a local folder. It is a _7z_ archive format so you will need to install either [7zip for Windows](https://www.7-zip.org/) or other alternative tools.
 
-    ![DietPi-download-image](assets/images/dietpi-download-nativepc.jpg)
+    ![DietPi-download-image](assets/images/dietpi-download-nativepc.jpg){: width="1152" height="337" loading="lazy"}
 
     Download [Rufus](https://rufus.ie/) and run the application. There is a portable version of Rufus available which doesn't require any local installation.
 
@@ -144,7 +144,7 @@ Select the following tabs for the installation description of your target.
     !!! warning "All data on the USB medium and on the target PCs harddisk will be erased!"
         Before starting the installation first make a backup of the data available on the target PC and USB drive if you need it later again!
 
-    ![Rufus UEFI selections screenshot](assets/images/dietpi-rufus-uefi.jpg)
+    ![Rufus UEFI selections screenshot](assets/images/dietpi-rufus-uefi.jpg){: width="474" height="580" loading="lazy"}
 
     <font size="+2">3. Boot the target PC and install the image on the local disk</font>
 
@@ -155,11 +155,11 @@ Select the following tabs for the installation description of your target.
 
     During the initial boot, the following dialog may appear to boot from the USB stick:
 
-    ![Bootloader menu screenshot](assets/images/dietpi-uefi-boot.jpg)
+    ![Bootloader menu screenshot](assets/images/dietpi-uefi-boot.jpg){: width="483" height="230" loading="lazy"}
 
     After booting the graphics selection dialog appears:
 
-    ![Clonezilla main menu screenshot](assets/images/dietpi-uefi-boot-graphic.jpg)
+    ![Clonezilla main menu screenshot](assets/images/dietpi-uefi-boot-graphic.jpg){: width="834" height="394" loading="lazy"}
 
     You can select the default settings. In case of problems, please select "Safe graphic settings".
 
@@ -169,15 +169,15 @@ Select the following tabs for the installation description of your target.
 
     Select the image file to be installed on the target PCs harddisk. Normally you should only see one single option:
 
-    ![Clonezilla source image selection screenshot](assets/images/dietpi-boot-clonezilla.jpg)
+    ![Clonezilla source image selection screenshot](assets/images/dietpi-boot-clonezilla.jpg){: width="656" height="198" loading="lazy"}
 
     After this, you have to select the target PCs harddisk where your DietPi shall be installed. In this example there is only one harddisk present:
 
-    ![Clonezilla target drive selection screenshot](assets/images/dietpi-boot-clonezilla-run.jpg)
+    ![Clonezilla target drive selection screenshot](assets/images/dietpi-boot-clonezilla-run.jpg){: width="853" height="181" loading="lazy"}
 
     After this, the installation process starts with several steps, e.g. showing the process of the image copying:
 
-    ![Clonezilla processing screenshot](assets/images/dietpi-boot-partclone.jpg)
+    ![Clonezilla processing screenshot](assets/images/dietpi-boot-partclone.jpg){: width="657" height="467" loading="lazy"}
 
     These steps take some time, be patient! Otherwise buy an SSD. :-)  
     At the end the system executes a shutdown.
@@ -194,7 +194,7 @@ Select the following tabs for the installation description of your target.
 
     One of the options of a virtual machine is [__Oracle VirtualBox__](https://www.oracle.com/virtualization/virtualbox/).
 
-    ![DietPi-VirtualBox-program](assets/images/dietpi-VirtualBox-program.png)
+    ![DietPi-VirtualBox-program](assets/images/dietpi-VirtualBox-program.png){: width="1593" height="814" loading="lazy"}
 
     <font size="+2">Prerequisites</font>
 
@@ -211,27 +211,27 @@ Select the following tabs for the installation description of your target.
     Download the **DietPi VirtualBox file** "DietPi_VirtualBox-x86_64-Buster.7z" from [`dietpi.com`](https://dietpi.com/#download) and   
     unzip the downloaded file to a local folder. It is a _7z_ archive format so you will need to install either [7zip for Windows](https://www.7-zip.org/) or other alternative tools.
 
-    ![DietPi-VirtualBox-download-image](assets/images/dietpi-VirtualBox-Download.png)
+    ![DietPi-VirtualBox-download-image](assets/images/dietpi-VirtualBox-Download.png){: width="1152" height="733" loading="lazy"}
 
     The zip file contains a couple of files, the important one is the .ova file which has to be imported into VirtualBox.
 
-    ![DietPi VirtualBox 7zip archive content](assets/images/dietpi-VirtualBox-7zip-file.png)
+    ![DietPi VirtualBox 7zip archive content](assets/images/dietpi-VirtualBox-7zip-file.png){: width="533" height="83" loading="lazy"}
 
     <font size="+2">2. Import of the .ova file in VirtualBox</font>
 
     As next, the VirtualBox virtual machine has to be setup by importing the .ova file (via \File\Import Appliance):
 
-    ![VirtualBox appliance import screenshot](assets/images/dietpi-VirtualBox-import1.png)
+    ![VirtualBox appliance import screenshot](assets/images/dietpi-VirtualBox-import1.png){: width="483" height="308" loading="lazy"}
 
     In the following dialog the user has to choose DietPi_VirtualBox-x86_64-Buster.ova as the file which shall be imported.
 
-    ![VirtualBox appliance import selection screenshot](assets/images/dietpi-VirtualBox-import2.png)
+    ![VirtualBox appliance import selection screenshot](assets/images/dietpi-VirtualBox-import2.png){: width="971" height="775" loading="lazy"}
 
     Keep the settings in the next dialog and klick “Import”.
 
     After the importing has finished the DietPi VirtualBox virtual machine is present:
 
-    ![VirtualBox virtual machine list screenshot](assets/images/dietpi-VirtualBox-VB-Machine.png)
+    ![VirtualBox virtual machine list screenshot](assets/images/dietpi-VirtualBox-VB-Machine.png){: width="245" height="55" loading="lazy"}
 
     <font size="+2">3. First boot of the new VirtualBox image</font>
 
@@ -248,7 +248,7 @@ Select the following tabs for the installation description of your target.
 
     One of the options of a virtual machine is [__VMware Workstation Player__](https://www.vmware.com/de/products/workstation-player/workstation-player-evaluation.html).
 
-    ![DietPi-VMware-program](assets/images/dietpi-VMware-program.png)
+    ![DietPi-VMware-program](assets/images/dietpi-VMware-program.png){: width="769" height="588" loading="lazy"}
 
     !!! info "Tested with Windows 10"
         This description relates to VMware Workstation 16 Player on a Microsoft Windows system.  
@@ -270,22 +270,22 @@ Select the following tabs for the installation description of your target.
     Download the **DietPi VMware file** "DietPi_VMware-x86_64-Buster.7z" from [`dietpi.com`](https://dietpi.com/#download) and   
     unzip the downloaded file to a local folder. It is a _7z_ archive format so you will need to install either [7zip for Windows](https://www.7-zip.org/) or other alternative tools.
 
-    ![DietPi VMware download image](assets/images/dietpi-VMware-Download.png)
+    ![DietPi VMware download image](assets/images/dietpi-VMware-Download.png){: width="1223" height="749" loading="lazy"}
 
     The zip file contains a couple of files, the important two are the `.vmx` and `.vmdk` file which have to be copied to a VMware machine folder (The folder can be located anywhere on the PCs harddisk).
 
-    ![DietPi VMware 7zip archive content](assets/images/dietpi-VMware-7zip-file.png)
+    ![DietPi VMware 7zip archive content](assets/images/dietpi-VMware-7zip-file.png){: width="525" height="104" loading="lazy"}
 
     <font size="+2">2. Add the files in VMware</font>
 
     As next, the VMware virtual machine is setup by just opening the `.vmx` file (via ***Open a Virtual Machine***):
 
-    ![VMware file open screenshot](assets/images/dietpi-VMware-import1.png)
+    ![VMware file open screenshot](assets/images/dietpi-VMware-import1.png){: width="715" height="585" loading="lazy"}
 
     In the following dialog the user has to navigate to the directory where the `.vmx` and `.vmdk` file were stored. Then choose DietPi_VMware-x86_64-Buster(`.vmx`) as the file which shall be opened.  
     After this the DietPi VMware virtual machine is present and can be started:
 
-    ![VMware virtual machine list screenshot](assets/images/dietpi-VMware-VM-Machine.png)
+    ![VMware virtual machine list screenshot](assets/images/dietpi-VMware-VM-Machine.png){: width="714" height="588" loading="lazy"}
 
     <font size="+2">3. First boot of the new VMware image</font>
 
@@ -338,7 +338,7 @@ A login prompt will appear. Use the initial credentials:
 
 To further proceed you’ll need to accept the DietPi GPL license. Hit the ++enter++ key on your keyboard to do this.
 
-![dietpi-login01](assets/images/dietpi-login01.jpg)
+![dietpi-login01](assets/images/dietpi-login01.jpg){: width="640" height="371" loading="lazy"}
 
 DietPi will then immediately begin to search for and install updated software packages, which will take some time to complete.
 
@@ -347,13 +347,13 @@ Once the packages have been updated, DietPi will ask you to confirm whether you 
 !!! info "DietPi Survey"
     DietPi Survey is **optional, and not enabled by default**. It is anonymous, secured and requires a minimal data transfer. ALL the shared details are published on the [`dietpi.com/survey`](https://dietpi.com/survey/) page. Checkout and see how DietPi is used!
 
-![dietpi-data](assets/images/dietpi-data-policy.jpg)
+![dietpi-data](assets/images/dietpi-data-policy.jpg){: width="642" height="385" loading="lazy"}
 
 The default DietPi password is public, so you’ll be asked to change this at the next stage for both the `root` and `dietpi` user accounts. Select OK and hit ++enter++, then provide your password (twice) to confirm.
 
 You can change the password again later by typing `passwd` at the terminal or also via the command line script `dietpi-config` (within the "Security options").
 
-![dietpi-password](assets/images/dietpi-password-01.jpg)
+![dietpi-password](assets/images/dietpi-password-01.jpg){: width="643" height="386" loading="lazy"}
 
 ## 5. Further steps
 
@@ -362,13 +362,13 @@ You can return to the **DietPi-Software** tool to make further changes at any ti
 
 If you want to make further changes to your DietPi configuration, you can run `dietpi-launcher` at the terminal to view all the available DietPi tools, including **DietPi-Update** to update your device and **DietPi-Backup** to back up your device.
 
-For more details, check [DietPi Tools](../dietpi_tools) section.
+For more details, check [DietPi Tools](../dietpi_tools/) section.
 
 ## YouTube tutorials (made by community)
 
 A video tutorial on _How to install and initially configure DietPi_ made by Roberto Jorge.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Me0PfuNLl-Q?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope" allowfullscreen></iframe>
+<iframe src="https://www.youtube-nocookie.com/embed/Me0PfuNLl-Q?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
 
 Further videos:
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -27,7 +27,7 @@ Links to special software packages are located at the end of the according softw
 - [Munin monitoring on Raspberry Pi/DietPi](https://advanxer.com/blog/2019/02/munin-monitoring-on-raspberrypi-dietpi/)  
   Munin - a network resource monitoring tool analyzing your resources on the network to avoid trouble.  
 
-    ![advanxer.com logo](assets/images/dietpi-references-advanxer.com-logo.png){: width=150px}
+    ![advanxer.com logo](assets/images/dietpi-references-advanxer.com-logo.png){: width="200" height="55" loading="lazy"}
 
     Many thanks to `advanxer.com` for generating this nice description.  
     See also <http://munin-monitoring.org>, <https://github.com/munin-monitoring/munin>.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,7 +8,7 @@ Welcome to **December 2020 release** :octicons-gift-16: of DietPi. This release 
 
 As a summary of 2020, DietPi had **8 releases** with over **175 000** downloads. It brought 128 :octicons-light-bulb-16: improvements and changes, as well as 119 :octicons-issue-closed-16: bug fixes.
 
-![DietPi Release in 2020](assets/images/dietpi-release-gift.jpg){: width=65% }
+![DietPi Release in 2020](assets/images/dietpi-release-gift.jpg){: width="447" height="298" loading="lazy"}
 
 ### New optimised software packages
 
@@ -18,7 +18,7 @@ It is a new software package included in the DietPi optimised list. Portainer si
 
 For more details check the [documentation page](../software/programming/#portainer).
 
-![DietPi Optimised Software Portainer](assets/images/dietpi-software-portainer.jpg)
+![Portainer screenshot](assets/images/dietpi-software-portainer.jpg){: width="1159" height="636" loading="lazy"}
 
 Many thanks to @Joulinar for implementing this software option - more details here: MichaIng/DietPi#3933
 
@@ -28,7 +28,7 @@ PaperMC extends the list of Minecraft servers supported by DietPi. It is a high 
 
 For more details check the [documentation page](../software/gaming/#papermc).
 
-![DietPi Optimised Software PaperMC](assets/images/dietpi-software-papermc.jpg)
+![Minecraft screenshot](assets/images/dietpi-software-papermc.jpg){: width="606" height="363" loading="lazy"}
 
 Many thanks to @ravenclaw900 for implementing this software option: MichaIng/DietPi#3828
 
@@ -38,7 +38,7 @@ Become part of the Tor Project and turn your DietPi into a Tor relay to help oth
 
 For more details check the [documentation page](../software/advanced_networking/#tor-relay).
 
-![advanced-networking-tor](assets/images/dietpi-software-advanced-networking-tor.png){: width="150px"}
+![advanced-networking-tor](assets/images/dietpi-software-advanced-networking-tor.png){: width="200" height="121" loading="lazy"}
 
 Many thanks to @ravenclaw900 for implementing this software option: MichaIng/DietPi#3921.
 
@@ -48,7 +48,7 @@ Validating, recursive, caching DNS resolver is now available for install and int
 
 For more details check the [documentation page](../software/dns_servers/#unbound)
 
-![unbound](assets/images/dietpi-software-unbound.jpg)
+![Unbound monitor screenshot](assets/images/dietpi-software-unbound.jpg){: width="603" height="331" loading="lazy"}
 
 Many thanks to @ravenclaw900 for implementing this software option: MichaIng/DietPi#3872
 
@@ -58,7 +58,7 @@ Bitwarden_RS is a an unofficial Bitwarden password manager server with web UI, w
 
 For more details check the [documentation page](../software/cloud/#bitwarden_rs)
 
-![Bitwarden_RS](assets/images/dietpi-software-bitwarden_rs.jpg)
+![Bitwarden_RS](assets/images/dietpi-software-bitwarden_rs.jpg){: width="2000" height="823" loading="lazy"}
 
 Many thanks to @CactiChameleon9 for implementing this software option (MichaIng/DietPi!3724).
 
@@ -68,7 +68,7 @@ Many thanks to @CactiChameleon9 for implementing this software option (MichaIng/
 
  For more details on how to install DietPi, check the [documentation](../hardware/#raspberry-pi).
 
- ![DietPi Raspberry Pi 400](assets/images/dietpi-raspberry-pi-400-back.jpg)
+ ![Raspberry Pi 400 photo](assets/images/dietpi-raspberry-pi-400-back.jpg){: width="800" height="571" loading="lazy"}
 
 ### Changes / Improvements / Optimisations
 
@@ -81,7 +81,7 @@ Many thanks to @CactiChameleon9 for implementing this software option (MichaIng/
     you can enable daily APT update checks (default value). The result is shown in the DietPi login banner, in a similar way an available DietPi update is presented.
 
     dietpi-automated_APT_package_update
-    ![dietpi Automated APT packages update](assets/images/dietpi-automated_APT_package_update.jpg)
+    ![dietpi Automated APT packages update](assets/images/dietpi-automated_APT_package_update.jpg){: width="670" height="326" loading="lazy"}
 
     Set
 
@@ -95,7 +95,7 @@ Many thanks to @CactiChameleon9 for implementing this software option (MichaIng/
 
 - **DietPi Documentation** has been extended. It covers now all the **[DietPi Optimised Software](../software/)** categories. Many thanks to @StephanStS for bringing all these updates.
 
-    ![DietPi Documentation](assets/images/dietpi-docs-categories.jpg)
+    ![DietPi Documentation](assets/images/dietpi-docs-categories.jpg){: width="1335" height="667" loading="lazy"}
 
 - **DietPi-Globals** :octicons-arrow-right-16: In DietPi scripts, the PATH variable is now overwritten with the Debian/bash system default to assure that no broken or manipulated PATH can be passed via e.g. "su" or "sudo -E".
 
@@ -205,7 +205,8 @@ For all additional issues that may appear after release, please see the followin
 
 - **Bazarr** is the latest application from DietPi optimised software portfolio. It is a companion application to Sonarr and Radarr, and manages and downloads subtitles based on defined requirements.
 
-    ![DietPi-Software Bazarr](assets/images/dietpi-software_bazarr.jpg)
+    ![DietPi-Software Bazarr](assets/images/dietpi-software_bazarr.jpg){: width="1898" height="1080" loading="lazy"}
+
     For more details on installation and configuration open [DietPi Optimised Software - Bazarr](../software/bittorrent#bazarr) page.
 
     Companion application to Sonarr and Radarr, which manages and downloads subtitles based on your requirements, now available for install. Open [Bazarr](../software/bittorrent#bazarr) page in [Optimised software](../software/).

--- a/docs/software/dns_servers.md
+++ b/docs/software/dns_servers.md
@@ -14,9 +14,9 @@
 
     Choose **Software Optimised** and select one or more items. Finally click on `Install`. DietPi will do all the necessary steps to install and start these software items.
 
-    ![DietPi software](../assets/images/dietpi-software.jpg)
+    ![DietPi software](../assets/images/dietpi-software.jpg){: width="643" height="365" loading="lazy"}
 
-    To see all the DietPi configurations options, review [DietPi Tools](../../dietpi_tools) section.
+    To see all the DietPi configurations options, review [DietPi Tools](../../dietpi_tools/) section.
 
 [Return to the **Optimised Software list**](../../software/)
 

--- a/docs/software/dns_servers.md
+++ b/docs/software/dns_servers.md
@@ -164,7 +164,7 @@ For more details see [unbound "about" description](https://nlnetlabs.nl/projects
     systemctl restart unbound
     ```
 
-    The used DNS servers are examples only and can be replaced by your favorite one. A list of public DNS providers, their IPs and their in cases included ad blocking / adult content blocking features are available on Wikipedia:
+    The used DNS servers are examples only and can be replaced by your favorite one. A list of public DNS providers, their IP addresses and their in cases included ad blocking / adult content blocking features are available on Wikipedia:
     
     - https://wikipedia.org/wiki/Public_recursive_name_server
 

--- a/docs/software/dns_servers.md
+++ b/docs/software/dns_servers.md
@@ -105,7 +105,7 @@ Wikipedia: <https://wikipedia.org/wiki/Pi-hole>
 
 YouTube video tutorial #1: *Raspberry Pi / Pi-hole / Diet-Pi / Network wide Ad Blocker !!!!*.
 
-<iframe src="https://www.youtube-nocookie.com/embed/RO2_eZlVrj4" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+<iframe src="https://www.youtube-nocookie.com/embed/RO2_eZlVrj4?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
 
 YouTube video tutorial #2: [`Block ads everywhere with Pi-hole and PiVPN on DietPi`](https://www.youtube.com/watch?v=qbLEHlKkGiE)  
 YouTube video tutorial #3 (German language): [`Raspberry Pi & DietPi : Pi-hole der Werbeblocker für Netzwerke mit Anleitung für AVM FritzBox`](https://www.youtube.com/watch?v=vXUvFWhXW6c&list=PLQIL7cyHMGboXtOzwAcX4hGPW6ECbVinp&index=6)  

--- a/docs/software/dns_servers.md
+++ b/docs/software/dns_servers.md
@@ -26,7 +26,7 @@ Pi-hole is a DNS sinkhole with web interface that will block ads for any device 
 
 - Also Installs: [Webserver stack](../webserver_stack/)
 
-![DietPi DNS server software Pi-hole](../assets/images/dietpi-software-dnsserver-pihole.png){: width="500px"}
+![DietPi DNS server software Pi-hole](../assets/images/dietpi-software-dnsserver-pihole.png){: width="500" height="410" loading="lazy"}
 
 === "Access the web interface"
 
@@ -56,7 +56,7 @@ Pi-hole is a DNS sinkhole with web interface that will block ads for any device 
 
     Simply enter the IP address of your Pi-hole device under "DNS server":
 
-    ![DietPi DNS server software router setup](../assets/images/dietpi-software-dnsserver-router-setup.png){: width="500px"}
+    ![DietPi DNS server software router setup](../assets/images/dietpi-software-dnsserver-router-setup.png){: width="400" height="240" loading="lazy"}
 
     On your Pi-hole device, you will need to set a different DNS server.  
     Depending on your router configuration, if you don't do this step, the Pi-hole device may not be able to access the internet. It's highly recommended to have the device running Pi-hole, pointing to a DNS server outside your network.
@@ -105,7 +105,7 @@ Wikipedia: <https://wikipedia.org/wiki/Pi-hole>
 
 YouTube video tutorial #1: *Raspberry Pi / Pi-hole / Diet-Pi / Network wide Ad Blocker !!!!*.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/RO2_eZlVrj4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube-nocookie.com/embed/RO2_eZlVrj4" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
 
 YouTube video tutorial #2: [`Block ads everywhere with Pi-hole and PiVPN on DietPi`](https://www.youtube.com/watch?v=qbLEHlKkGiE)  
 YouTube video tutorial #3 (German language): [`Raspberry Pi & DietPi : Pi-hole der Werbeblocker für Netzwerke mit Anleitung für AVM FritzBox`](https://www.youtube.com/watch?v=vXUvFWhXW6c&list=PLQIL7cyHMGboXtOzwAcX4hGPW6ECbVinp&index=6)  
@@ -116,9 +116,9 @@ YouTube video tutorial #4 (German language): [`Raspberry Pi Zero W mit Pi-hole -
 Unbound is a validating, recursive, caching DNS resolver.  
 For more details see [unbound "about" description](https://nlnetlabs.nl/projects/unbound/about/).
 
-![DietPi DNS server software unbound logo](../assets/images/dietpi-software-dnsserver-unbound.svg){: width="150px"}
+![DietPi DNS server software unbound logo](../assets/images/dietpi-software-dnsserver-unbound.svg){: width="150" height="34" loading="lazy"}
 
-![DietPi DNS server software unbound screenshot](../assets/images/dietpi-software-unbound.jpg){: width="500px"}
+![DietPi DNS server software unbound screenshot](../assets/images/dietpi-software-unbound.jpg){: width="500" height="274" loading="lazy"}
 
 === "Default DNS ports"
 


### PR DESCRIPTION
+ Load images and YouTube frames "lazy", i.e. in case the browser support, when scrolling close to them.
+ Define width and height explicitly for images, so that the aspect ratio is preserved even if it is still loading. The default CSS "max-width: 100%; height: auto" makes the aspect ration being correctly applied when images are resized on small screens.
+ Contrary to CSS, the HTML "width" and "height" attributes do not require the "px" units to be set.
+ Do not display images larger than the original image size, which usually looks blurry.
+ Do not grant YouTube iframes extended permissions. Apply fullscreen permission via feature policy "allow" attribute, deny autoplay and all sensor permissions. Consequently add "?rel=0" to only show related videos of the same channel when the video has finished.