### PR TITLE
Extend Mosquitto docs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -226,6 +226,7 @@ Meveric
 MiB
 MichaIng
 microcontroller
+microcontrollers
 MicroSol
 Minecraft
 MineOS

--- a/docs/software/hardware_projects.md
+++ b/docs/software/hardware_projects.md
@@ -131,8 +131,11 @@ PiJuice is an all in one, battery based power supply HAT for the RPi, featuring 
         nano /var/lib/pijuice/pijuice_config.JSON
         ```
 
-    Restart services to apply any changes:  
-    `dietpi-services restart`
+    Restart the service to apply any changes:
+
+    ```sh
+    systemctl restart pijuice
+    ```
 
 === "Update firmware"
 
@@ -198,8 +201,11 @@ WebIOPi allows you to control your Raspberry Pi's GPIO hardware using a web inte
     - Enter the username `webiopi`
     - Enter your new password twice
 
-    You must also restart the `webiopi` service for your new password to take effect:  
-    `service webiopi restart`
+    You must also restart the `webiopi` service for your new password to take effect:
+
+    ```sh
+    systemctl restart webiopi
+    ```
 
 === "Access WebIOPi over the internet"
 
@@ -265,14 +271,66 @@ Libraries resp. flows: <https://flows.nodered.org>
 
 ## Mosquitto
 
-Eclipse Mosquitto™ is an open source (EPL/EDL licensed) message broker that implements the MQTT protocol versions 3.1 and 3.1.1.  
-MQTT provides a lightweight method of carrying out messaging using a publish/subscribe model. This makes it suitable for "Internet of Things" messaging such as with low power sensors or mobile devices such as phones, embedded computers or microcontroller like the Arduino.
+Eclipse Mosquitto™ is an open-source (EPL/EDL-licensed) message broker that implements the MQTT protocol versions 3.1 and 3.1.1.  
+MQTT provides a lightweight method of carrying out messaging using a publish/subscribe model. This makes it suitable for IoT (Internet of Things) messaging such as with low power sensors or mobile devices such as phones, embedded computers or microcontrollers like the Arduino.
 
 ![Mosquitto logo](../assets/images/dietpi-software-hardwareprojects-mosquitto.png){: width="100" height="76" loading="lazy"}
 
+=== "Client configuration"
+
+    Mosquitto by default listens on network port **1883**. Clients need to authenticate with the following credentials:
+
+    - Username: `mosquitto`
+    - Password: `<your global password>` (default: `dietpi`)
+
+=== "Server configuration"
+
+    - Config directory: `/etc/mosquitto`
+    - Config file: `/etc/mosquitto/mosquitto.conf`
+    - Password file: `/etc/mosquitto/passwd`
+
+    To change the default authentication password for the `dietpi` user, run the following command:
+
+    ```sh
+    mosquitto_passwd /etc/mosquitto/passwd mosquitto
+    ```
+
+    To create a new authentication user, run the following command:
+
+    ```sh
+    mosquitto_passwd /etc/mosquitto/passwd
+    ```
+
+    After changes have been done, you need to restart the service:
+
+    ```sh
+    systemctl restart mosquitto
+    ```
+
+    For further details, see the official documentation, linked below.
+
+=== "View logs"
+
+    To view Mosquitto server logs, run the following command:
+
+    ```sh
+    journalctl -u mosquitto
+    ```
+
+=== "Update to lastest version"
+
+    Mosquitto is installed via its official APT repository, hence the following commands can be used to update it to the latest version:
+
+    ```sh
+    apt update
+    apt install mosquitto
+    ```
+
 ***
 
-Official documentation: <https://mosquitto.org/documentation>
+Official website: <https://mosquitto.org/>  
+Official documentation: <https://mosquitto.org/documentation/>  
+Source code: <https://github.com/eclipse/mosquitto>
 
 ## Blynk Server
 
@@ -330,8 +388,11 @@ Also installs:
 
 === "Run test script"
 
-    Once you create a project in the iOS/Android app, replace the following with your `auth code`, then run the command:  
-    `blynk-client Replace_With_Your_Auth_Code`
+    Once you create a project in the iOS/Android app, run the command:
+
+    ```sh
+    blynk-client <replace_with_your_auth_code>
+    ```
 
 === "Update to the latest version"
 
@@ -351,7 +412,7 @@ See <https://www.audiophonics.fr/fr/kits-et-modules-diy/audiophonics-pi-spc-v2-m
 
 ???+ notes "Ensure correct GPIO pins!"
 
-    Please ensure the correct GPIO pins are used, when connecting Pi-SPC to RPi (see image below).  
+    Please ensure the correct GPIO pins are used, when connecting Pi-SPC to RPi (see image below).
 
     ![Raspberry Pi GPIO scheme](../assets/images/dietpi-software-hardwareprojects-audiophonics-gpionumbers.png){: width="400" height="119" loading="lazy"}
 
@@ -430,7 +491,7 @@ exit
 
 ### Install information
 
-The data location for InfluxDB is stored resp. linked with symbolic links to the DietPi userdata directory: `/mnt/dietpi_userdata/influxdb`.
+The data location for InfluxDB is stored resp. linked with symbolic links to the DietPi userdata directory: `/mnt/dietpi_userdata/influxdb`
 
 ***
 
@@ -448,10 +509,13 @@ Remark: Grafana binaries are specific to the CPU architecture, therefore, swappi
 === "Prerequisites"
 
     A database server is required for Grafana. As Grafana offers many options (InfluxDB/MySQL), we have not automatically installed either as manual configuration may be preferred.  
-    However, we highly recommend installing InfluxDB:  
-    `dietpi-software install 74`
+    However, we highly recommend installing InfluxDB:
 
-    Then follow the database creation guide [here](#influxdb-database-optimized-to-save-time-based-data-as-logs-or-data-from-a-sensor).
+    ```sh
+    dietpi-software install 74
+    ```
+
+    Then follow the database creation guide [here](#influxdb).
 
 === "Access to the web interface"
 
@@ -481,7 +545,6 @@ Remark: Grafana binaries are specific to the CPU architecture, therefore, swappi
 
 === "Installation information"
 
-    The data location for Grafana is stored resp. linked with symbolic links to the DietPi userdata directory:  
-    `/mnt/dietpi_userdata/grafana`.
+    The data location for Grafana is stored resp. linked with symbolic links to the DietPi userdata directory: `/mnt/dietpi_userdata/grafana`
 
 [Return to the **Optimised Software list**](../../software/)

--- a/docs/software/hardware_projects.md
+++ b/docs/software/hardware_projects.md
@@ -317,7 +317,7 @@ MQTT provides a lightweight method of carrying out messaging using a publish/sub
     journalctl -u mosquitto
     ```
 
-=== "Update to lastest version"
+=== "Update to latest version"
 
     Mosquitto is installed via its official APT repository, hence the following commands can be used to update it to the latest version:
 


### PR DESCRIPTION
The authentication is implemented with: https://github.com/MichaIng/DietPi/pull/4223
Hence we might want to wait for the release to merge this.

Additionally:
- Align code blocks, using fenced code with shell syntax highlighting.
- Consequently use "systemctl restart <service_name>" to restart only the intended service with the native systemctl command.
- Fix an internal InfluxDB header link