### PR TITLE
[Node-RED] Skip audit output on update

### DIFF
--- a/docs/software/hardware_projects.md
+++ b/docs/software/hardware_projects.md
@@ -258,7 +258,7 @@ Node-RED is a visual tool for wiring together hardware devices, APIs and online 
     ```sh
     systemctl stop node-red
     cd /mnt/dietpi_userdata/node-red
-    sudo -u nodered npm up node-red
+    sudo -u nodered npm up --no-audit node-red
     systemctl start node-red
     ```
 


### PR DESCRIPTION
Otherwise one will see deprecation warnings and vulnerabilities. That is interesting output for the developer but might be confusing for end users. Do you agree @StephanStS ?

There is also a `--no-fund` option to hide output like that:
```
7 packages are looking for funding
  run `npm fund` for details
```
But I think its fair towards the package developers to keep that.