### PR TITLE
Update TigerVNC download URL

### DIFF
--- a/docs/software/remote_desktop.md
+++ b/docs/software/remote_desktop.md
@@ -48,7 +48,7 @@ Run a **Desktop environment** on your device and access it accessed remotely via
     systemctl status vncserver
     ```
 
-    Although any VNC viewer may work, the latest official TigerVNC viewer can be downloaded here: <https://bintray.com/tigervnc/stable/tigervnc/>
+    Although any VNC viewer may work, the latest official TigerVNC viewer can be downloaded here: <https://sourceforge.net/projects/tigervnc/files/stable/>
 
     #### Connection Details
 


### PR DESCRIPTION
It has finally moved from Bintray to SourceForge: https://github.com/TigerVNC/tigervnc/issues/1236