### PR TITLE
Update emonPi/emonHub docs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -109,10 +109,10 @@ EEPROM
 Emby
 eMMC
 emoncms
-EmonCMS
-EmonPi
-EmonTH
-EmonTX
+emonCMS
+emonPi
+emonTH
+emonTX
 EPL
 EQ
 ESXi

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -110,6 +110,7 @@ Emby
 eMMC
 emoncms
 emonCMS
+emonHub
 emonPi
 emonTH
 emonTX

--- a/docs/software.md
+++ b/docs/software.md
@@ -139,7 +139,7 @@
 ## [Home Automation](../software/home_automation/)
 
 - [**Home Assistant - Open-source home automation platform running on Python 3**](../software/home_automation/#home-assistant)
-- [**EmonPi - Lightweight Energy usage stats with EmonPi PCB**](../software/home_automation/#emonpi)
+- [**emonHub - Data collector for the emonPi energy monitor addon board**](../software/home_automation/#emonhub)
 - [**Domoticz - Multi platform Home Automation System**](../software/home_automation/#domoticz)
 - [**TasmoAdmin - Administrative website for Tasmota devices**](../software/home_automation/#tasmoadmin)
 

--- a/docs/software/home_automation.md
+++ b/docs/software/home_automation.md
@@ -3,7 +3,7 @@
 ## Overview
 
 - [**Home Assistant - Open-source home automation platform running on Python 3**](#home-assistant)
-- [**EmonPi - Lightweight Energy usage stats with EmonPi PCB**](#emonpi)
+- [**emonHub - Data collector for the emonPi energy monitor addon board**](#emonhub)
 - [**Domoticz - Multi platform Home Automation System**](#domoticz)
 - [**TasmoAdmin - Administrative website for Tasmota devices**](#tasmoadmin)
 
@@ -81,68 +81,68 @@ Home Assistant is an open-source home automation platform running on Python 3. T
 
 Official documentation: <https://home-assistant.io/docs>
 
-## EmonPi
+## emonHub
 
-Turn your Raspberry Pi into a energy usage monitor with web interface.
+Turn your Raspberry Pi into an energy usage monitor with web interface.
 
-![EmonPi wen interface screenshot](../assets/images/dietpi-software-homeautomation-emonpi.png){: width="400" height="237" loading="lazy"}
+![emonCMS web interface screenshot](../assets/images/dietpi-software-homeautomation-emonpi.png){: width="400" height="237" loading="lazy"}
 
 ### Installation
 
-The DietPi optimized installation for EmonPi is aimed at users who want the following:
+The DietPi optimised installation for emonPi is aimed at users who want the following:
 
-- Ultra lightweight alternative installation to the official EmonPi image, with all the optimisations and features of DietPi. Allowing additional uses for your RPi device (e.g.: ownCloud server): [htop image of RPi Zero @700 MHz](https://dietpi.com/downloads/misc/EmonPi_Guide/EmonPi_DietPi_zero_700mhz.jpg), running our EmonPi installation.
+- Ultra lightweight alternative installation to the official emonPi image, with all the optimisations and features of DietPi. Allowing additional uses for your RPi device (e.g.: ownCloud server): [htop image of RPi Zero @700 MHz](https://dietpi.com/downloads/misc/EmonPi_Guide/EmonPi_DietPi_zero_700mhz.jpg), running our emonHub installation.
 - Real time and historical energy usage statistics uploaded to the [emoncms.org](https://emoncms.org/) cloud, viewable from a web browser and the [Android App](https://openenergymonitor.org/forum-archive/node/11260.html), from anywhere in the world.
-- Use an existing RPi, or, do not wish to purchase the full EmonPi package (e.g.: case).
-- Comfortable attaching the EmonPi to your Raspberry Pi GPIO. No soldering or wiring is required.
+- Use an existing RPi, or, do not wish to purchase the full emonPi package with case and LCD.
+- Comfortable attaching the emonPi to your Raspberry Pi GPIO. No soldering or wiring is required.
 
 ### Missing support
 
-The DietPi installation does not support:
+The DietPi installation does not setup all features OOTB, but they can be manually enabled:
 
-- RF transmission. RF receiver (sensor nodes) is supported (e.g.: EmonTX/EmonTH)
-- EmonPi LCD screen.
-- Local EmonCMS webserver on RPi. All EmonPi data is sent to [emoncms.org](https://emoncms.org/) cloud.
+- RF transmission. RF receiver (sensor nodes) is supported (e.g.: emonTX/emonTH)
+- emonPi LCD screen
+- Local emonCMS webserver on RPi. All emonPi data is sent to [emoncms.org](https://emoncms.org/) cloud by default.
 
 ### Requirements
 
 The following hardware is required:
 
-- 1x EmonPi PCB - [Order one here](https://shop.openenergymonitor.com/emonpi-shield-kit-no-enclosure/): Select 1 Clip-on CT Current Sensor (all together £33.42), or sensors based on your needs. [Image of what you will receive](https://cdn2.bigcommerce.com/server4400/98a75/product_images/optionset_rule_images/28_zoom_1429716170.jpg).  
+- 1x emonPi PCB - [Order one here](https://shop.openenergymonitor.com/emonpi-shield-kit-no-enclosure/): Select 1 Clip-on CT Current Sensor (all together £33.42), or sensors based on your needs. [Image of what you will receive](https://cdn2.bigcommerce.com/server4400/98a75/product_images/optionset_rule_images/28_zoom_1429716170.jpg).  
   This installation also supports the optional temperature sensor, but its not required.
 - 1x Raspberry Pi (any model)
-- 1x Good quality Raspberry Pi PSU. The EmonPi does not need its own power supply. It will draw power directly through the GPIOs on the RPi.
-- Alternatively you can power the RPi through the EmonPi shield via GPIO. For this, add the EmonPi PSU to the chart and skip buying a dedicated PSU for the RPi itself.
+- 1x Good quality Raspberry Pi PSU. The emonPi does not need its own power supply. It will draw power directly through the GPIOs on the RPi.
+- Alternatively you can power the RPi through the emonPi shield via GPIO. For this, add the emonPi PSU to the chart and skip buying a dedicated PSU for the RPi itself.
 
 === "During Installation"
 
     You will be asked to create a [emoncms.org](https://emoncms.org/) account and input your unique API Key. DietPi will automatically apply your API Key during installation.
     If you did not complete this, or wish to change the API Key on your system, please follow the steps located here, otherwise continue below.
 
-=== "Attach EmonPi to RPi"
+=== "Attach emonPi to RPi"
 
     - Attach GPIO extender/riser to RPi:  
-      ![Raspberry Pi EmonPi attachment photo 1](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g2.jpg){: width="400" height="322" loading="lazy"}  
-      ![Raspberry Pi EmonPi attachment photo 2](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g3.jpg){: width="400" height="277" loading="lazy"}
-    - Attach EmonPi to RPi:  
-      ![Raspberry Pi EmonPi attachment photo 3](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g5.jpg){: width="400" height="478" loading="lazy"}
+      ![Raspberry Pi emonPi attachment photo 1](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g2.jpg){: width="400" height="322" loading="lazy"}  
+      ![Raspberry Pi emonPi attachment photo 2](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g3.jpg){: width="400" height="277" loading="lazy"}
+    - Attach emonPi to RPi:  
+      ![Raspberry Pi emonPi attachment photo 3](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g5.jpg){: width="400" height="478" loading="lazy"}
     - Verify pins are visible:  
-      ![Raspberry Pi EmonPi attachment photo 4](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g4.jpg){: width="400" height="300" loading="lazy"}
+      ![Raspberry Pi emonPi attachment photo 4](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g4.jpg){: width="400" height="300" loading="lazy"}
 
 === "Connect power sensor"
 
-    Connect the sensor to measure the power consumption to the EmonPi:
+    Connect the sensor to measure the power consumption to the emonPi:
 
-    - Plug the 3.5mm power consumption sensor into the EmonPi:  
-      ![Raspberry Pi EmonPi attachment photo 5](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g6.jpg){: width="400" height="714" loading="lazy"}
+    - Plug the 3.5mm power consumption sensor into the emonPi:  
+      ![Raspberry Pi emonPi attachment photo 5](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g6.jpg){: width="400" height="714" loading="lazy"}
     - Clip the power consumption sensor onto a positive (red) cable (cables are live, use caution):  
-      ![Raspberry Pi EmonPi attachment photo 6](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g7.jpg){: width="400" height="234" loading="lazy"}
+      ![Raspberry Pi emonPi attachment photo 6](../assets/images/dietpi-software-homeautomation-emonpi-emonPi-g7.jpg){: width="400" height="234" loading="lazy"}
 
 === "Setup Inputs and feeds for power sensor"
 
     #### Assign a name to your power sensor input
 
-    Inputs are the real time value of the data received from the EmonPi. We will assign a name to the power value so we can use it later.
+    Inputs are the real time value of the data received from the emonPi. We will assign a name to the power value so we can use it later.
 
     - Login to your `https://emoncms.org` account
     - Click `Setup` at the top right of screen, then click `Inputs`
@@ -150,16 +150,16 @@ The following hardware is required:
 
     #### Setup feed
 
-    Feeds allow your EmonPi data (inputs) to be saved to a database. You will need feeds setup if you want to view historical (and pretty) stats.
+    Feeds allow your emonPi data (inputs) to be saved to a database. You will need feeds setup if you want to view historical (and pretty) stats.
 
     - Login to your `https://emoncms.org` account
     - Click `Setup` at the top right of screen, then click `Inputs`
     - Select the spanner on the far right of *Power WATT*
     - Check the screen matches the following image  
-      ![EmonPi setup screenshot 1](../assets/images/dietpi-software-homeautomation-emonpi-emoncms-emonpi_addfeed.png){: width="1079" height="89" loading="lazy"}  
+      ![emonPi setup screenshot 1](../assets/images/dietpi-software-homeautomation-emonpi-emoncms-emonpi_addfeed.png){: width="1079" height="89" loading="lazy"}  
       then click `add`
     - To verify the feed is active, click `Setup` at the top right of screen, then click `Inputs`. You should see `log` under *Process list* of *Power WATT*:  
-      ![EmonPi setup screenshot 2](../assets/images/dietpi-software-homeautomation-emonpi-emoncms-emonpi_inputs.png){: width="731" height="79" loading="lazy"}  
+      ![emonPi setup screenshot 2](../assets/images/dietpi-software-homeautomation-emonpi-emoncms-emonpi_inputs.png){: width="731" height="79" loading="lazy"}  
 
 === "Setup 'My Electric' App"
 
@@ -175,6 +175,12 @@ The following hardware is required:
 
     Then click `Save`.  
     Press ++f5++ to refresh the page and view your energy consumption.
+
+***
+
+Official usage guide: <https://guide.openenergymonitor.org/>  
+Official config docs: <https://github.com/openenergymonitor/emonhub/blob/stable/configuration.md>  
+Source code: <https://github.com/openenergymonitor/emonhub>
 
 ## Domoticz
 


### PR DESCRIPTION
As of: https://github.com/MichaIng/DietPi/pull/4357

+ Renamed "EmonPi" to "emonHub". The "emonPi" is the addon board hardware while our software option is the data collector backend which collects data from the emonPi, processes and sends it to frontends, like the emonCMS web interface, provided as public instance emoncms.org which is used by default. Making this clear by correct naming helps avoid confusing and allows us to implement emonCMS as local web interface as well. This was planned once but dropped as it lead to heavy regular disk writes. This however can be avoided by using Redis as RAM-based storage, which makes a local emonCMS attractive again to avoid relying on a public provider and regular public network connectivity.
+ Make clear that while we do not configure any other frontend or LCD screen by default (which is part of the all-in-one package with SBC + emonPi + LCD + case + OS image), everything can be setup manually, of course. OpenEnergyMonitor provides installer scripts for everything, if needed.
+ Add official docs, guides and source code links