### PR TITLE
Add Tor logs command

### DIFF
--- a/docs/software/advanced_networking.md
+++ b/docs/software/advanced_networking.md
@@ -84,6 +84,14 @@ It also Installs:
     To verify that the traffic is being routed through Tor you can check the following:  
     On the connected WiFi device, go to the following URL: <https://check.torproject.org>
 
+=== "View logs"
+
+    Tor service logs can be viewed with the following command:
+
+    ```sh
+    journalctl -t tor
+    ```
+
 ***
 
 Wikipedia: <https://wikipedia.org/wiki/Tor_(anonymity_network)>  

--- a/docs/software/distributed_projects.md
+++ b/docs/software/distributed_projects.md
@@ -115,6 +115,14 @@ Contribute a node to the Tor network, which allows people to be anonymous on the
     apt upgrade
     ```
 
+=== "View logs"
+
+    Tor service logs can be viewed with the following command:
+
+    ```sh
+    journalctl -t tor
+    ```
+
 ***
 
 Official documentation: <https://community.torproject.org/relay/setup>


### PR DESCRIPTION
In this case it indeed needs to be `-t` instead of `-u`, since `tor.service` is just a dummy wrapper while the actual binary is called by `tor@default.service` and other instances could be spawned. But all of them share the `tor` tag.