### PR TITLE
Update and align Gitea and Gogs docs

### DIFF
--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -367,7 +367,7 @@ Your very own GitHub style server, with web interface.
         - Application URL: `http://<your.domain/IP>:3000/`
         - Log Path: `/var/log/gogs`
     - Scroll to the bottom of page and select "Install Gogs".
-    - Depending on whether the base URL above was entered correctly/is accessible by the connected browser, you may need to reconnect to the web page using the IP address, e.g.: `http://<your.IP>:3000`
+    - Depending on whether the application URL above was entered correctly/is accessible by the connected browser, you may need to reconnect to the web page using the IP address, e.g.: `http://<your.IP>:3000`
     - Once the page has reloaded, you will need to click `Register` to create the admin account.
 
 === "External access"
@@ -428,8 +428,9 @@ Your very own GitHub style server, with web interface.
     - Change the following values only:
         - Host: `/run/mysqld/mysqld.sock`
         - Password: `<your global password>` (default: `dietpi`)
-        - Gitea base URL: `http://<your.domain/IP>:3000/`
-        - Log path: `/var/log/gitea` (However, file logging is disabled by default.)
+        - SSH Server Domain: `<your.domain/IP>`
+        - Gitea Base URL: `http://<your.domain/IP>:3000/`
+        - Log Path: `/var/log/gitea` (However, file logging is disabled by default.)
     - Scroll to the bottom of page and select "Install Gitea".
     - Depending on whether the base URL above was entered correctly/is accessible by the connected browser, you may need to reconnect to the web page using the IP address, e.g.: `http://<your.IP>:3000`
     - Once the page has reloaded, you will need to click `Register` to create the admin account.

--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -377,7 +377,7 @@ Your very own GitHub style server, with web interface.
     - Port: 3000
     - Protocol: TCP+UDP
 
-    If an external access is used, HTTPS is strongly recommended to increase your system security. You can get a free certificate e.g. via [dietpi-letsencrypt](../../dietpi_tools/#dietpi-letsencrypt).
+    If an external access is used, HTTPS is strongly recommended to increase your system security. You can get a free certificate e.g. via [`dietpi-letsencrypt`](../../dietpi_tools/#dietpi-letsencrypt).
 
 === "View logs"
 
@@ -441,11 +441,11 @@ Your very own GitHub style server, with web interface.
     - Port: 3000
     - Protocol: TCP+UDP
 
-    If an external access is used, HTTPS is strongly recommended to increase your system security. You can get a free certificate e.g. via [dietpi-letsencrypt](../../dietpi_tools/#dietpi-letsencrypt).
+    If an external access is used, HTTPS is strongly recommended to increase your system security. You can get a free certificate e.g. via [`dietpi-letsencrypt`](../../dietpi_tools/#dietpi-letsencrypt).
 
 === "Fail2Ban integration"
 
-    Using Fail2Ban your can block IPs after failed login attempts. This hardens your system against e.g. brute-force attacks.
+    Using Fail2Ban your can block IP addresses after failed login attempts. This hardens your system against e.g. brute-force attacks.
 
     === "When using journal logging (default)"
 


### PR DESCRIPTION
I almost went crazy with the Gitea systemd Fail2Ban integration: What `journalctl -u gitea` does not show, but only debugging like
```
fail2ban-regex --print-all-missed "systemd-journal" gitea
fail2ban-regex -l heavydebug "systemd-journal" gitea
```
reveals: Gitea logs color codes to the console and while `journalctl` does not show them, they are actually there, and Fail2Ban parses them. Hence the extended regex compared to when using file logging:
```
failregex = Failed authentication attempt for \x1b\[1m.+\x1b\[0m from \x1b\[1m<HOST>:\d+\x1b\[0m:
```

Sadly Gogs does not log failed login attempts at all, hence no Fail2Ban integration possible.