### PR TITLE
Add meaningful title and description meta tags

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         # https://github.com/actions/python-versions/releases
-        python-version: '3.9.9'
+        python-version: '3.9.10'
     - name: Install MkDocs
       id: mkdocs
       if: always() && steps.python.outcome == 'success'

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,3 +1,8 @@
+---
+title: Getting started with DietPi
+description: How to get started after the the DietPi first run setup, learn about available DietPi tools and get an overview with the DietPi-Launcher
+---
+
 # Getting started
 
 ## Overview
@@ -12,7 +17,7 @@ This will be the first screen displayed.
 
 ## DietPi-Launcher
 
-Run `dietpi-launcher` to see all available DietPi tools. It provides a quick way to run any of the DietPi tools: From installing **DietPi optimized software items** to simple configure your device, from enabling services to start to backup your installation and so on.
+Run `dietpi-launcher` to see all available DietPi tools. It provides a quick way to run any of the [DietPi tools](../dietpi_tools/): From installing [**DietPi optimized software items**](../software/) to simple [configure](../dietpi_tools/#dietpi-configuration) your device, from enabling services to start to backup your installation and so on.
 
 ![DietPi-Launcher screenshot](assets/images/dietpi-launcher.jpg){: width="642" height="366" loading="lazy"}
 
@@ -32,13 +37,13 @@ The list of DietPi optimised software includes:
 - Hotspots
 - System Stats
 - Hardware Projects
-- Stacks (LAMP/LEMP etc.)
+- Webserver Stacks (LAMP/LEMP etc.)
 - File Servers
 - Home Automation
 - Printing
 - and [much more...](../software/).
 
-To install and configure them use `dietpi-software` tool - [click for more details](../dietpi_tools/#dietpi-software).
+To install and configure them use the `dietpi-software` tool - [click for more details](../dietpi_tools/#dietpi-software).
 
 ![DietPi-Software screenshot](assets/images/dietpi-software.jpg){: width="643" height="365" loading="lazy"}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
-description: How to install DietPi on SBCs and virtualized environments. Install & configure optimised software and much more.
 title: DietPi Documentation
+description: How to install DietPi on SBCs, PCs and virtualized environments. Install & configure optimised software and much more.
 ---
 
 [![DietPi Logo](https://dietpi.com/images/dietpi-logo_180x180.png){: width="180" height="180" loading="lazy"}](https://dietpi.com/)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 ---
-description: Easy to follow tutorial to install & initially configure DietPi
 title: How to install DietPi
+description: Easy to follow tutorial to install & initially configure DietPi
 ---
 
 # How to install DietPi

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,7 +1,12 @@
+---
+title: External references and articles
+description: Read external references, articles and watch videos and guides about DietPi
+---
+
 # References
 
 At this page, links to general information are referenced.  
-Links to special software packages are located at the end of the according software package description in the "Optimized Software" documentation area.
+Links to special software packages are located at the end of the according software package description in the [Optimised Software](../software/) documentation area.
 
 ## General links
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,3 +1,8 @@
+---
+title: DietPi Release Notes
+description: Overview of DietPi releases with applied new software and features, hardware support, optimisations and bug fixes
+---
+
 # DietPi Releases
 
 - [v8.0 January 2022](v8_0/)

--- a/docs/socialmedia.md
+++ b/docs/socialmedia.md
@@ -1,3 +1,8 @@
+---
+title: DietPi Social Media Channels
+description: The social media channels maintained by the DietPi project team where you can contact us and get new about DietPi
+---
+
 # Social media
 
 ## DietPi on Twitter

--- a/docs/software.md
+++ b/docs/software.md
@@ -1,3 +1,8 @@
+---
+title: DietPi Software Options
+description: Overview of ready-to-run software options provided by DietPi-Software, cloud & backup servers, media streaming and web servers, BitTorrent, forums, system monitoring & management and more
+---
+
 # DietPi software options
 
 ## Overview


### PR DESCRIPTION
By default the navigation menu text is used as page title, which is not always self-explaining, like the "Overview" pages for software and releases. As description meta tag, the global documentation description "Official documentation pages for DietPi OS" is used, so this adds more specific page descriptions.

Could or should be expanded to individual release notes and software categories, so this is a start to cover all top level pages. Title and description don't need to be given both, if the title (navigation menu text) is sufficiently self-explaining, the description alone can be given.

This also adds some internal links and mininal text changes.