### PR TITLE
Fix OpenBazaar docs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -54,4 +54,4 @@ jobs:
     - name: Run lychee to check README and HTML files
       if: always() && steps.lychee.outcome == 'success'
       # "429 Too Many Requests" on GitHub despite token
-      run: ./lychee -En --require-https --exclude '(wiringpi.com|fonts.gstatic.com|^admin@koel.dev$|^root@192.168.1.20$|bridges.torproject.org|www.spigotmc.org|www.audiophonics.fr|help.realvnc.com)' -a 429 --github-token '${{ secrets.GITHUB_TOKEN }}' -b build README.md 'build/**/*.html'
+      run: ./lychee -En --require-https --exclude '(^https://pydio.com|^https://twitter.com|wiringpi.com|fonts.gstatic.com|^admin@koel.dev$|^root@192.168.1.20$|bridges.torproject.org|www.spigotmc.org|www.audiophonics.fr|help.realvnc.com)' -a 429 --github-token '${{ secrets.GITHUB_TOKEN }}' -b build README.md 'build/**/*.html'

--- a/docs/software/social.md
+++ b/docs/software/social.md
@@ -212,7 +212,38 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins.
         - For Windows, download `OpenBazaar2Client-x.y.z-Setup-64.exe`
     2. Start the OpenBazaar client and add your server:
         - Click "New"
-        - Enter the IPv4 address of your DietPi device, the username and password you entered during the OpenBazaar server install.
+        - Enter the IPv4 address of your DietPi device, the username and password you entered during the OpenBazaar server install
+        - Turn off SSL, unless you manually enabled it, including TLS certificate setup
+
+=== "Configuration"
+
+    - Config and data directory:  
+        `/mnt/dietpi_userdata/openbazaar`
+    - Main config file:  
+        `/mnt/dietpi_userdata/openbazaar/config`
+
+    For changes to take effect, the service needs to be restarted:
+
+    ```sh
+    systemctl restart openbazaar
+    ```
+
+=== "Service handling"
+
+    The DietPi OpenBazaar implementation creates a systemd service `openbazaar.service` to start and control the OpenBazaar server. The following commands can be used:
+
+    - Start: `systemctl start openbazaar`
+    - Stop: `systemctl stop openbazaar`
+    - Restart: `systemctl restart openbazaar`
+    - Print status: `systemctl status openbazaar`
+
+=== "View logs"
+
+    Logs are done to the system journal an can be viewed via:
+
+    ```sh
+    journalctl -u openbazaar
+    ```
 
 ***
 
@@ -261,7 +292,7 @@ Synapse is a server, written in Python, for communication using the Matrix proto
     - Stop: `systemctl stop synapse`
     - Restart: `systemctl restart synapse`
     - Reload config: `systemctl reload synapse`
-    - Print status: `systemctl start synapse`
+    - Print status: `systemctl status synapse`
 
 === "View logs"
 

--- a/docs/software/social.md
+++ b/docs/software/social.md
@@ -209,10 +209,8 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins.
  
     1. Download the client from: <https://github.com/OpenBazaar/openbazaar-desktop/releases>
     2. Start the OpenBazaar client and add your server:
-        - Click Menu (top right)
-        - Click New Server
-        - Select Standalone
-        - Enter the IPv4 address of your DietPi device, the username and password you applied during the OpenBazaar server install.
+        - Click "New"
+        - Enter the IPv4 address of your DietPi device, the username and password you entered during the OpenBazaar server install.
 
 ***
 

--- a/docs/software/social.md
+++ b/docs/software/social.md
@@ -203,23 +203,22 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins.
 
 ![OpenBazaar client screenshot](../assets/images/dietpi-software-social-openbazaar.png){: width="400" height="240" loading="lazy"}
 
-=== "OpenBazaar Client"
+=== "OpenBazaar client setup"
 
-    The client will allow you to browse and trade, within the OpenBazaar market network.  
-    <https://www.openbazaar.org/download/>
+    The client will allow you to browse and trade, within the OpenBazaar market network.
+ 
+    1. Download the client from: <https://github.com/OpenBazaar/openbazaar-go/releases>
+    2. During the installation, you will be asked to enter a username, password, and allowed IP address.
+    3. Next, you will need to open the OpenBazaar client and add your server:
+        - Click Menu (top right)
+        - Click New Server
+        - Select Standalone
+        - Enter the IP address of your DietPi device, and, the username and password you applied in step 2.
 
-=== "Connecting OpenBazaar Client to your OpenBazaar Server"
+***
 
-    Step 1:  
-    During installation, you will be asked to enter a username, password, and allowed IP address.
-
-    Step 2:  
-    Next, you will need to open the OpenBazaar Client and add your server:
-
-    - Click Menu (top right)
-    - Click New Server
-    - Select Standalone
-    - Enter the IP address of your DietPi device, and, the username and password you applied in step 1.
+Source code: <https://github.com/OpenBazaar/openbazaar-go>  
+License: [MIT](https://github.com/OpenBazaar/openbazaar-go/blob/master/LICENSE)
 
 ## Synapse
 

--- a/docs/software/social.md
+++ b/docs/software/social.md
@@ -205,15 +205,14 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins.
 
 === "OpenBazaar client setup"
 
-    The client will allow you to browse and trade, within the OpenBazaar market network.
+    The client will allow you to browse and trade within the OpenBazaar market network.
  
-    1. Download the client from: <https://github.com/OpenBazaar/openbazaar-go/releases>
-    2. During the installation, you will be asked to enter a username, password, and allowed IP address.
-    3. Next, you will need to open the OpenBazaar client and add your server:
+    1. Download the client from: <https://github.com/OpenBazaar/openbazaar-desktop/releases>
+    2. Start the OpenBazaar client and add your server:
         - Click Menu (top right)
         - Click New Server
         - Select Standalone
-        - Enter the IP address of your DietPi device, and, the username and password you applied in step 2.
+        - Enter the IPv4 address of your DietPi device, the username and password you applied during the OpenBazaar server install.
 
 ***
 

--- a/docs/software/social.md
+++ b/docs/software/social.md
@@ -207,15 +207,17 @@ Oldschool: Think Napster, but for buying and selling stuff using your Bitcoins.
 
     The client will allow you to browse and trade within the OpenBazaar market network.
  
-    1. Download the client from: <https://github.com/OpenBazaar/openbazaar-desktop/releases>
+    1. Download the client from: <https://github.com/mobazha/openbazaar-desktop/releases>
+        - Expand "Assents" below the latest releases
+        - For Windows, download `OpenBazaar2Client-x.y.z-Setup-64.exe`
     2. Start the OpenBazaar client and add your server:
         - Click "New"
         - Enter the IPv4 address of your DietPi device, the username and password you entered during the OpenBazaar server install.
 
 ***
 
-Source code: <https://github.com/OpenBazaar/openbazaar-go>  
-License: [MIT](https://github.com/OpenBazaar/openbazaar-go/blob/master/LICENSE)
+Source code: <https://github.com/mobazha/openbazaar-go>  
+License: [MIT](https://github.com/mobazha/openbazaar-go/blob/master/LICENSE)
 
 ## Synapse
 


### PR DESCRIPTION
The official website is down, but clients can be downloaded from GitHub. Download and setup instrcutions have been merged, source code and license links added.

Whether we keep or drop OpenBazaar in general, e.g. by moving to a fork, is discussed at: https://github.com/MichaIng/DietPi/issues/5213