### PR TITLE
Fix Chromium GPU link

### DIFF
--- a/docs/software/desktop.md
+++ b/docs/software/desktop.md
@@ -182,7 +182,7 @@ Not all devices support GPU acceleration with Chromium.
 
 #### Where can I check the status of GPU acceleration?
 
-Once Chromium is running, simply go to the following address: <chrome://gpu>
+Once Chromium is running, simply go to the following address: `chrome://gpu`
 
 #### Enable support for Widevine DRM protected content on RPi
 


### PR DESCRIPTION
It showed up as an HTML element before, and even when linked correctly it isn't clickable, so I just placed it in inline code.