### PR TITLE
fix link to automatic base installation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -99,7 +99,7 @@ Select the following tabs for the installation description of your target.
 
     ??? info "Option: Automatic base installation at first boot (running an _unattended base installation_)"
 
-        DietPi offers the option for an automatic first boot installation. See section ["How to do an automatic base installation at first boot"](../usage/#how-to-do-an-automatic-base-installation-at-first-boot) for details.
+        DietPi offers the option for an automatic first boot installation. See section ["How to do an automatic base installation at first boot"](../usage/#how-to-do-an-automatic-base-installation-at-first-boot-dietpi-automation) for details.
 
     ???+ hint "Initial boot duration"
         Due to an automated resize of the root filesystem and basic setup steps, this initial boot takes a longer time than further system booting sequences. It may last up to a couple of minutes, depending on the system drive and hardware.


### PR DESCRIPTION
The link here currently doesn't jump to the correct anchor https://dietpi.com/docs/install/#3-prepare-the-first-boot