### PR TITLE
Remove all YouTube video embeddings

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -58,4 +58,4 @@ jobs:
     - name: Run lychee to check README and HTML files
       if: always() && steps.lychee.outcome == 'success'
       # "429 Too Many Requests" on GitHub despite token
-      run: ./lychee -En --require-https --cache --exclude '^(https://fonts.gstatic.com/$|http://wiringpi.com/|https://pydio.com/|https://www.spigotmc.org/|https://help.realvnc.com/|https://blynk.io/|www.php.net|https://play.google.com/store/apps/details)' -a 429 --github-token '${{ secrets.GITHUB_TOKEN }}' -b build README.md 'build/**/*.html'
+      run: ./lychee -En --require-https --cache --exclude '^(https://fonts.gstatic.com/$|http://wiringpi.com/|https://pydio.com/|https://www.spigotmc.org/|https://help.realvnc.com/|https://help.roonlabs.com/|https://blynk.io/|https://play.google.com/store/apps/details)' -a 429 --github-token '${{ secrets.GITHUB_TOKEN }}' -b build README.md 'build/**/*.html'

--- a/docs/install.md
+++ b/docs/install.md
@@ -950,14 +950,9 @@ For more details, check [DietPi Tools](../dietpi_tools/) section.
 
 ## YouTube tutorials (made by community)
 
-A video tutorial on _How to install and initially configure DietPi_ made by Roberto Jorge.
-
-<iframe src="https://www.youtube-nocookie.com/embed/Me0PfuNLl-Q?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
-
-Further videos:
-
-- YouTube video #1: [Installing DietPi : Fast Linux For Any Raspberry Pi!!!](https://www.youtube.com/watch?v=U-UXenzA2m8){: class="nospellcheck"}
-- YouTube video #2: [How Install Diet Pi Raspberry Pi 4 Or Any SBC - Install Set Up Configure](https://www.youtube.com/watch?v=qH0YsFNIyFo){: class="nospellcheck"}
-- YouTube video #3: [Headless install of Dietpi | No Monitor, No LAN, No router login | Pre Configure WiFi](https://www.youtube.com/watch?v=vlMpn9u0Y4o){: class="nospellcheck"}
-- YouTube video #4: [Installing DietPi on Raspberry Pi, First Boot and Configuration](https://www.youtube.com/watch?v=LzJpAUufyy0){: class="nospellcheck"}
-- YouTube video #5 (German language): [Raspberry Pi 4 & DietPi - die schnelle Alternative - Grundinstallation einfach erklärt](https://www.youtube.com/watch?v=J5yPeJFLSO0&list=PLQIL7cyHMGboXtOzwAcX4hGPW6ECbVinp&index=7){: class="nospellcheck"}
+- YouTube video #1: [DietPi - HOW To Install & Initial Configuration on the Raspberry Pi 4](https://www.youtube.com/watch?v=Me0PfuNLl-Q)
+- YouTube video #2: [Installing DietPi : Fast Linux For Any Raspberry Pi!!!](https://www.youtube.com/watch?v=U-UXenzA2m8){: class="nospellcheck"}
+- YouTube video #3: [How Install Diet Pi Raspberry Pi 4 Or Any SBC - Install Set Up Configure](https://www.youtube.com/watch?v=qH0YsFNIyFo){: class="nospellcheck"}
+- YouTube video #4: [Headless install of Dietpi | No Monitor, No LAN, No router login | Pre Configure WiFi](https://www.youtube.com/watch?v=vlMpn9u0Y4o){: class="nospellcheck"}
+- YouTube video #5: [Installing DietPi on Raspberry Pi, First Boot and Configuration](https://www.youtube.com/watch?v=LzJpAUufyy0){: class="nospellcheck"}
+- YouTube video #6 (German language): [Raspberry Pi 4 & DietPi - die schnelle Alternative - Grundinstallation einfach erklärt](https://www.youtube.com/watch?v=J5yPeJFLSO0&list=PLQIL7cyHMGboXtOzwAcX4hGPW6ECbVinp&index=7){: class="nospellcheck"}

--- a/docs/releases/v7_0.md
+++ b/docs/releases/v7_0.md
@@ -40,9 +40,7 @@ Find sample applications using Docker Compose and more details in the [documenta
 
 [Steam](../../software/gaming/#steam) for ARM processors has been a feature request for many years. Since it became possible to install on ARM boards, it's now available also on DietPi. [Box86](../../software/gaming/#box86) is installed automatically, as dependency.
 
-The Steam platform is one of the largest digital distribution platform for gaming. Still, on ARMv7 boards it has limited features and game support. Here are few sample games running with [Box86](../../software/gaming/#box86):
-
-<iframe src="https://www.youtube-nocookie.com/embed/z-4aGNqZ724?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+The Steam platform is one of the largest digital distribution platform for gaming. Still, on ARMv7 boards it has limited features and game support. This YouTube video shows a few sample games running with [Box86](../../software/gaming/#box86): <https://www.youtube.com/watch?v=z-4aGNqZ724>
 
 !!! info ""
 

--- a/docs/software/advanced_networking.md
+++ b/docs/software/advanced_networking.md
@@ -58,9 +58,7 @@ The WiFi HotSpot package turns your device into a wireless hotspot/access point.
 
 ***
 
-YouTube video tutorial (German language): `Raspberry Hotspot: Internet Sperren umgehen mit eigenen WiFi Hotspot unter DietPi (für alle Geräte)`.
-
-<iframe src="https://www.youtube-nocookie.com/embed/3ZROq90tM_s?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+YouTube video tutorial (German language): [Raspberry Hotspot: Internet Sperren umgehen mit eigenen WiFi Hotspot unter DietPi (für alle Geräte)](https://www.youtube.com/watch?v=3ZROq90tM_s){:class="nospellcheck"}
 
 ## Tor HotSpot
 
@@ -100,9 +98,7 @@ It also Installs:
 ***
 
 Wikipedia: <https://wikipedia.org/wiki/Tor_(anonymity_network)>  
-YouTube video tutorial: *DietPi Tor Hotspot Setup on Raspberry Pi 3 B Plus*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/rik-ABzSoHM?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+YouTube video tutorial: [DietPi Tor Hotspot Setup on Raspberry Pi 3 B Plus](https://www.youtube.com/watch?v=rik-ABzSoHM)
 
 ## HAProxy
 

--- a/docs/software/bittorrent.md
+++ b/docs/software/bittorrent.md
@@ -493,9 +493,7 @@ Automatically download your favorite TV shows, as they become available.
 
 ***
 
-YouTube video tutorial: *How to install and configure Sonarr on Raspberry Pi with DietPi*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/3h0GvdKcR0Y?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+YouTube video tutorial: [How to install and configure Sonarr on Raspberry Pi with DietPi](https://www.youtube.com/watch?v=3h0GvdKcR0Y)
 
 ## Radarr
 
@@ -563,9 +561,7 @@ Automatically download your favorite movies, as they become available.
 
 ***
 
-YouTube video tutorial: *How to install and configure Radarr on Raspberry Pi with DietPi*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/ji9CgSBcf5E?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+YouTube video tutorial: [How to install and configure Radarr on Raspberry Pi with DietPi](https://www.youtube.com/watch?v=ji9CgSBcf5E)
 
 ## Bazarr
 

--- a/docs/software/camera.md
+++ b/docs/software/camera.md
@@ -133,10 +133,7 @@ from any RPi camera, USB camera or an IP camera network stream.
 Github page: <https://github.com/ccrisan/motioneye>  
 Wiki: <https://github.com/ccrisan/motioneye/wiki>  
 Tutorial: [motionEye on DietPi on Raspberry Pi: keeping an eye on things](https://mansfield-devine.com/speculatrix/2018/12/motioneye-on-dietpi-on-raspberry-pi/)  
-YouTube video tutorial (German language): `DietPi & motionEye - Vollautomatische Installation inkl. Wlan Konfiguration, Updates und Anwendung`.
-
-<iframe src="https://www.youtube-nocookie.com/embed/vQxL3TfQK5E?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
-
+YouTube video tutorial (German language): [DietPi & motionEye - Vollautomatische Installation inkl. Wlan Konfiguration, Updates und Anwendung](https://www.youtube.com/watch?v=vQxL3TfQK5E){:class="nospellcheck"}  
 License: [GPLv3](https://github.com/ccrisan/motioneye/blob/dev/LICENSE)
 
 ## mjpg-streamer

--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -267,12 +267,8 @@ Nextcloud gives you access to all your files wherever you are. Store your docume
 ***
 
 Website: <https://nextcloud.com/>  
-Official documentation: <https://docs.nextcloud.com/server/latest/admin_manual/contents.html>
-
-YouTube video tutorial #1: *DietPi Nextcloud Setup on Raspberry Pi 3 B Plus*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/Q3R2RqFSyE4?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
-
+Official documentation: <https://docs.nextcloud.com/server/latest/admin_manual/contents.html>  
+YouTube video tutorial #1: [DietPi Nextcloud Setup on Raspberry Pi 3 B Plus](https://www.youtube.com/watch?v=Q3R2RqFSyE4)  
 YouTube video tutorial #2: [DietPi Docker Nextcloud External Storage Setup with SAMBA SERVER on RPI3B](https://www.youtube.com/watch?v=NOb12BuNpZ8)
 
 ## Nextcloud Talk

--- a/docs/software/dns_servers.md
+++ b/docs/software/dns_servers.md
@@ -130,14 +130,9 @@ Pi-hole is a DNS sinkhole with web interface that will block ads for any device 
 Official website: <https://pi-hole.net/>  
 Official documentation: <https://docs.pi-hole.net/>  
 Wikipedia: <https://wikipedia.org/wiki/Pi-hole>  
-Source code: <https://github.com/pi-hole>
-
-DietPi Blog: [Pi-Hole & Unbound: How to have ad-free & safer internet in just few minutes](https://dietpi.com/blog/?p=564)
-
-YouTube video tutorial #1: *Raspberry Pi / Pi-hole / Diet-Pi / Network wide Ad Blocker !!!!*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/RO2_eZlVrj4?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
-
+Source code: <https://github.com/pi-hole>  
+DietPi Blog: [Pi-Hole & Unbound: How to have ad-free & safer internet in just few minutes](https://dietpi.com/blog/?p=564)  
+YouTube video tutorial #1: [Raspberry Pi / Pi-hole / Diet-Pi / Network wide Ad Blocker !!!!](https://www.youtube.com/watch?v=RO2_eZlVrj4)  
 YouTube video tutorial #2: [Block ads everywhere with Pi-hole and PiVPN on DietPi](https://www.youtube.com/watch?v=qbLEHlKkGiE){:class="nospellcheck"}  
 YouTube video tutorial #3 (German language): [Raspberry Pi & DietPi : Pi-hole der Werbeblocker für Netzwerke mit Anleitung für AVM FritzBox](https://www.youtube.com/watch?v=vXUvFWhXW6c&list=PLQIL7cyHMGboXtOzwAcX4hGPW6ECbVinp&index=6){:class="nospellcheck"}  
 YouTube video tutorial #4 (German language): [Raspberry Pi Zero W mit Pi-hole - günstiger Werbeblocker & Schritt für Schritt Anleitung unter DietPi](https://www.youtube.com/watch?v=IxWuMHu9IYk&list=PLQIL7cyHMGboXtOzwAcX4hGPW6ECbVinp&index=2){:class="nospellcheck"}  

--- a/docs/software/file_servers.md
+++ b/docs/software/file_servers.md
@@ -122,11 +122,8 @@ The Samba server lets you share files on your DietPi system with ease based on t
 
 ***
 
-Wikipedia: <https://wikipedia.org/wiki/Samba_(software)>
-
-YouTube video tutorial (German language): `Raspberry Pi als Datei-Server - einfache Installation eines Fileservers Samba unter DietPi`.
-
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/XB2F_Gyjw0s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+Wikipedia: <https://wikipedia.org/wiki/Samba_(software)>  
+YouTube video tutorial (German language): [Raspberry Pi als Datei-Server - einfache Installation eines Fileservers Samba unter DietPi](https://www.youtube.com/watch?v=XB2F_Gyjw0s){:class="nospellcheck"}
 
 ## vsftpd
 

--- a/docs/software/gaming.md
+++ b/docs/software/gaming.md
@@ -340,10 +340,7 @@ When ready, select **Start** to launch the emulator. Have fun!
 
 ***
 
-YouTube video tutorial #1: *Amiga on the Raspberry Pi with DietPi and Amiberry: I got the Pi 400 to work!*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/osBU7iVSQ78?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
-
+YouTube video tutorial #1: [Amiga on the Raspberry Pi with DietPi and Amiberry: I got the Pi 400 to work!](https://www.youtube.com/watch?v=osBU7iVSQ78)  
 YouTube video tutorial #2: [Amiga on the Raspberry Pi with DietPi and Amiberry: Workbench and Autobooting](https://www.youtube.com/watch?v=LU-G0PRNffQ)
 
 ## DXX-Rebirth

--- a/docs/software/media.md
+++ b/docs/software/media.md
@@ -688,9 +688,7 @@ A web interface media streaming server. Think Kodi, but using any device with a 
 
 ***
 
-YouTube video tutorial: *DietPi Emby Media Server Setup on Raspberry Pi 3 B Plus*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/zEcNNLCFngI?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+YouTube video tutorial: [DietPi Emby Media Server Setup on Raspberry Pi 3 B Plus](https://www.youtube.com/watch?v=zEcNNLCFngI)
 
 ## Plex Media Server
 
@@ -729,11 +727,8 @@ Plex organizes your video, music, and photo collections and streams them to all 
 
 ***
 
-Tutorial: [Setup Guide for Plex on Raspberry Pi](https://blog.barnettjones.com/2020/11/26/dietpi-plex-setup/)
-
-YouTube video tutorial (German language): `Raspberry Pi 4 - Plex TV Media Server unter DietPi installieren und Zugriff von aussen (FritzBox)`.
-
-<iframe src="https://www.youtube-nocookie.com/embed/EElrNjXc3aA?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+Tutorial: [Setup Guide for Plex on Raspberry Pi](https://blog.barnettjones.com/2020/11/26/dietpi-plex-setup/)  
+YouTube video tutorial (German language): [Raspberry Pi 4 - Plex TV Media Server unter DietPi installieren und Zugriff von aussen (FritzBox)](https://www.youtube.com/watch?v=EElrNjXc3aA){:class="nospellcheck"}
 
 ## Tautulli
 
@@ -1193,9 +1188,7 @@ Ubooquity is a free home server for your comics and ebooks library, with remote 
 
 ***
 
-YouTube video tutorial: *DietPi Ubooquity Comics and Ebook Reader on Raspberry Pi 3 B Plus*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/xUewleo7f2Q?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+YouTube video tutorial: [DietPi Ubooquity Comics and Ebook Reader on Raspberry Pi 3 B Plus](https://www.youtube.com/watch?v=xUewleo7f2Q)
 
 ## Komga
 

--- a/docs/software/remote_desktop.md
+++ b/docs/software/remote_desktop.md
@@ -236,9 +236,7 @@ Examples of TCP ports for Remot3.it:
 
 ***
 
-YouTube video tutorial (German language): `Raspberry Pi einfach fernsteuern: Remote.It SSH ohne VPN von überall - Installation unter DietPi`.
-
-<iframe src="https://www.youtube-nocookie.com/embed/V5MZXBo3hGw?rel?=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+YouTube video tutorial (German language): [Raspberry Pi einfach fernsteuern: Remote.It SSH ohne VPN von überall - Installation unter DietPi](https://www.youtube.com/watch?v=V5MZXBo3hGw){:class="nospellcheck"}
 
 ## VirtualHere
 

--- a/docs/software/social.md
+++ b/docs/software/social.md
@@ -168,11 +168,8 @@ Also Installs:
 
 ***
 
-Website: <https://sye.dk/sfpg>
-
-YouTube video tutorial: *DietPi: Easily set up Raspberry Pi projects (e.g. a shared photo gallery)*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/0by117lpq_o?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+Website: <https://sye.dk/sfpg>  
+YouTube video tutorial: [DietPi: Easily set up Raspberry Pi projects (e.g. a shared photo gallery)](https://www.youtube.com/watch?v=0by117lpq_o)
 
 ## Baïkal
 

--- a/docs/software/system_stats.md
+++ b/docs/software/system_stats.md
@@ -179,9 +179,7 @@ The following screenshots shall give an overview over the displaying features of
 
 ***
 
-YouTube video tutorial: *DietPi CloudShell (RPi / Odroid XU4)*
-
-<iframe src="https://www.youtube-nocookie.com/embed/O-W8Z33as_U?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+YouTube video tutorial: [DietPi CloudShell (RPi / Odroid XU4)](https://www.youtube.com/watch?v=O-W8Z33as_U)
 
 ### Configuration
 

--- a/docs/software/vpn.md
+++ b/docs/software/vpn.md
@@ -122,15 +122,9 @@ PiVPN is an OpenVPN and WireGuard installer and management tool. It also has a c
 ***
 
 Website: <https://pivpn.io/>  
-Documentation: <https://docs.pivpn.io/>
-
-YouTube video tutorial: *VPN configuration using Raspberry Pi and DietPi*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/aYPaDeqtMG8?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
-
-YouTube video tutorial: *DietPi PiVPN Server Setup on Raspberry Pi 3 B Plus*.
-
-<iframe src="https://www.youtube-nocookie.com/embed/0t0bwskZJFw?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+Documentation: <https://docs.pivpn.io/>  
+YouTube video tutorial: [VPN configuration using Raspberry Pi and DietPi](https://www.youtube.com/watch?v=aYPaDeqtMG8)  
+YouTube video tutorial: [DietPi PiVPN Server Setup on Raspberry Pi 3 B Plus](https://www.youtube.com/watch?v=0t0bwskZJFw)
 
 ## WireGuard
 
@@ -227,11 +221,8 @@ When installing using `dietpi-software`, you can choose whether to install WireG
 ***
 
 Website: <https://www.wireguard.com>  
-Wikipedia: <https://wikipedia.org/wiki/WireGuard>
-
-YouTube video tutorial (German language): `Raspberry Pi & PiVPN mit WireGuard: Installation unter DietPi mit NoIP und AVM Fritzbox`.
-
-<iframe src="https://www.youtube-nocookie.com/embed/yRkdzGmnvA4?rel=0" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+Wikipedia: <https://wikipedia.org/wiki/WireGuard>  
+YouTube video tutorial (German language): [Raspberry Pi & PiVPN mit WireGuard: Installation unter DietPi mit NoIP und AVM Fritzbox](https://www.youtube.com/watch?v=yRkdzGmnvA4){:class="nospellcheck"}
 
 ## Tailscale
 
@@ -299,11 +290,8 @@ Tailscale is a VPN service that makes the devices and applications you own acces
 [What is Tailscale?](https://tailscale.com/kb/1151/what-is-tailscale/)  
 Website: <https://tailscale.com/>  
 Docs: <https://tailscale.com/kb/>  
-License: [BSD 3-Clause](https://github.com/tailscale/tailscale/blob/main/LICENSE)
-
-YouTube video tutorial: *Tailscale VPN - WireGuard was never so easy!*
-
-<iframe src="https://www.youtube.com/embed/Kzyolu9yn0E" frameborder="0" allow="fullscreen" width="560" height="315" loading="lazy"></iframe>
+License: [BSD 3-Clause](https://github.com/tailscale/tailscale/blob/main/LICENSE)  
+YouTube video tutorial: [Tailscale VPN - WireGuard was never so easy!](https://www.youtube.com/watch?v=Kzyolu9yn0E)
 
 ## ZeroTier
 
@@ -386,14 +374,8 @@ ZeroTier is a smart programmable Ethernet switch for planet Earth. It allows all
 Website: <https://zerotier.com>  
 Wikipedia : <https://en.wikipedia.org/wiki/ZeroTier>  
 Source code: <https://github.com/zerotier/ZeroTierOne>
-License: [BSLv1.1](https://github.com/zerotier/ZeroTierOne/blob/master/LICENSE.txt)
-
-YouTube video tutorial: *ZeroTier Tutorial: Delivering the Capabilities of VPN, SDN, and SD-WAN via an Open Source System*.
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Bl_Vau8wtgc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-YouTube video tutorial: *How To Work Remotely Using ZeroTier & Windows Remote Desktop (RDP)*.
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/ZShna7v77xc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+License: [BSLv1.1](https://github.com/zerotier/ZeroTierOne/blob/master/LICENSE.txt)  
+YouTube video tutorial: [ZeroTier Tutorial: Delivering the Capabilities of VPN, SDN, and SD-WAN via an Open Source System](https://www.youtube.com/watch?v=Bl_Vau8wtgc)  
+YouTube video tutorial: [How To Work Remotely Using ZeroTier & Windows Remote Desktop (RDP)](https://www.youtube.com/watch?v=ZShna7v77xc)
 
 [Return to the **Optimised Software list**](../../software/)


### PR DESCRIPTION
and replace them with simple links. This is due to the fact that even with youtube-nocookie, such embeddings violate GDPR as long as there is no interactive consent button before the embedding is shown. And this again would require custom JavaScript or another 3rd party + the direct embedding benefit gets lost for users when several clicks are required, compared to a single click on a YouTube link, if interested.

A little bonus is that the pages load faster, it eliminates remaining browser console errors and we can remove a bunch of CSP rules.