### PR TITLE
Enhance Nextcloud brute-force protection docs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -556,6 +556,7 @@ stdout
 StackExchange
 StephanStS
 storages
+subdirectories
 subdirectory
 subshell
 sudo

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -631,6 +631,8 @@ UPnP
 uptime
 upvote
 UrBackup
+unbanned
+untrusted
 userdata
 userspace
 UTM

--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -193,10 +193,10 @@ Nextcloud gives you access to all your files wherever you are. Store your docume
         bantime = 600
         ```
 
-        Assure that the `logpath` matches the `'datadirectory'` value in the Nextcloud configuration file (`config.php`, see above), or the `'logfile'` value, if defined.
+        Assure that the `logpath` matches the `'datadirectory'` value in the Nextcloud configuration file (`config.php`, see above), or the `'logfile'` value if defined.
 
-        Properties not defined here are taken from the `[DEFAULT]` block in `/etc/fail2ban/jail.conf` or `/etc/fail2ban/jail.local`, if present. Note the setting `backend = auto`. By default, `backend` is set to `systemd` in `/etc/fail2ban/jail.conf`.  
-        As a result, Fail2Ban would ignore the `logpath` entry here in the jail `nextcloud.conf`, with the consequence, that Fail2Ban does not recognize an attack on Nextcloud (port 80, 443), even though attacks are logged in `/mnt/dietpi_userdata/nextcloud_data/nextcloud.log`.
+        Properties not defined here are taken from the `[DEFAULT]` block in `/etc/fail2ban/jail.conf`, or `/etc/fail2ban/jail.local` if present.  
+        Note the setting `backend = auto`: By default, `backend` is set to `systemd` in `/etc/fail2ban/jail.conf`. As a result, Fail2Ban would ignore the `logpath` entry here in the jail `nextcloud.local`, with the consequence that Fail2Ban does not recognize an attack on Nextcloud (port 80, 443), even though attacks are logged in `/mnt/dietpi_userdata/nextcloud_data/nextcloud.log`.
 
     1. Restart Fail2Ban:
 

--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -141,7 +141,8 @@ Nextcloud gives you access to all your files wherever you are. Store your docume
 
 === "Fail2Ban integration"
 
-    Using Fail2Ban your can block users after failed login attempts, which can further harden the brute-force protection of your Nextcloud instance.
+    Using Fail2Ban your can block users after failed login attempts, which can further harden the brute-force protection of your Nextcloud instance.  
+    To achieve this hardening, execute the following steps:
 
     1. If not done yet, install Fail2Ban:
 
@@ -164,7 +165,7 @@ Nextcloud gives you access to all your files wherever you are. Store your docume
             The entry of the trusted domains is important, because one of the Fail2Ban filters deals with trusted domain errors ("Trusted domain error", see below). By default, if you try to access with an untrusted domain, Nextcloud will show an error message.  
 
             !!! attention
-              Take care, if you use this "Trusted domain error" `failregex` option and you then reload the page several times (more often than `maxretry` value in the Fail2Ban jail file) you lockout yourself also for logging in via a trusted domain from the IP address you are using.
+                Take care, if you use this "Trusted domain error" `failregex` option and you then reload the page several times (more often than `maxretry` value in the Fail2Ban jail file) you lockout yourself also for logging in via a trusted domain from the IP address you are using.
 
     1. Create new ***Fail2Ban filter***, e.g. `/etc/fail2ban/filter.d/nextcloud.conf`:
 
@@ -192,9 +193,10 @@ Nextcloud gives you access to all your files wherever you are. Store your docume
         bantime = 600
         ```
 
-        Assure that the `logpath` matches the `'datadirectory'` value in the Nextcloud configuration file (`config.php` see above), or the `'logfile'` value if defined.
+        Assure that the `logpath` matches the `'datadirectory'` value in the Nextcloud configuration file (`config.php`, see above), or the `'logfile'` value, if defined.
 
-        Properties not defined here are taken from the `[DEFAULT]` block in `/etc/fail2ban/jail.conf` or `/etc/fail2ban/jail.local`, if present. Note the setting `backend = auto`: By default, `backend` is set to `systemd` in `/etc/fail2ban/jail.conf`. As a result, Fail2Ban would ignore the `logpath` entry here in the jail `nextcloud.conf`, with the consequence, that Fail2Ban does not recognize an attack on Nextcloud (port 80, 443) even though attacks are logged in `/mnt/dietpi_userdata/nextcloud_data/nextcloud.log`.
+        Properties not defined here are taken from the `[DEFAULT]` block in `/etc/fail2ban/jail.conf` or `/etc/fail2ban/jail.local`, if present. Note the setting `backend = auto`. By default, `backend` is set to `systemd` in `/etc/fail2ban/jail.conf`.  
+        As a result, Fail2Ban would ignore the `logpath` entry here in the jail `nextcloud.conf`, with the consequence, that Fail2Ban does not recognize an attack on Nextcloud (port 80, 443), even though attacks are logged in `/mnt/dietpi_userdata/nextcloud_data/nextcloud.log`.
 
     1. Restart Fail2Ban:
 

--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -131,40 +131,42 @@ Nextcloud gives you access to all your files wherever you are. Store your docume
 
 === "Brute-force protection"
 
-    Nextcloud offers built-in brute force protection and additionally a plugin ***Brute-force settings***.  
-    This will delay your login rate in case of several failed login attempts.
-
-    This protection can be extended with Fail2Ban (see following tab).
+    Nextcloud offers built-in brute-force protection, which will delay your login rate in case of several failed login attempts.
 
     See also:
 
-    - <https://apps.nextcloud.com/apps/bruteforcesettings>
     - <https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/bruteforce_configuration.html>
+
+    This protection can be extended with Fail2Ban (see following tab).
 
 === "Fail2Ban integration"
 
-    Using Fail2Ban your can block users after failed login attempts. This hardens your system, e.g. against brute force attacks.
+    Using Fail2Ban your can block users after failed login attempts, which can further harden the brute-force protection of your Nextcloud instance.
 
-    - Set options in the ***Nextcloud configuration file*** (typical `/var/www/nextcloud/config/config.php`):
+    1. If not done yet, install Fail2Ban:
 
-        - Add trusted domains if not already set via the `'trusted_domains'` entry.
+        ```sh
+        dietpi-software install 73
+        ```
+
+    1. Set options in the ***Nextcloud configuration file***, typically `/var/www/nextcloud/config/config.php`:
+
+        - Assure that all domains and IPs you use to access your Nextcloud instance were added to the `'trusted_domains'` entry.
 
             ```ini
             'trusted_domains' =>
              array (
                0 => 'localhost',
-               1 => '<your_trusted_domain>',
+               1 => 'your.domain/IP.org',
              ),
             ```
 
-            The entry of the trusted domains is important, because one of the Fail2Ban regular expressions in the Fail2Ban filter file ("Trusted domain error", see below) deals with trusted domain login errors. By default, if you login via a non trusted domain, Nextcloud will show an error login dialog.  
+            The entry of the trusted domains is important, because one of the Fail2Ban filters deals with trusted domain errors ("Trusted domain error", see below). By default, if you try to access with an untrusted domain, Nextcloud will show an error message.  
 
             !!! attention
               Take care, if you use this "Trusted domain error" `failregex` option and you then reload the page several times (more often than `maxretry` value in the Fail2Ban jail file) you lockout yourself also for logging in via a trusted domain from the IP address you are using.
 
-        - log file options: These are set to appropriate values by default (e.g. `log_level`, `log_type`) resp. DietPi defaults (`logfile` via `SOFTWARE_NEXTCLOUD_DATADIR` within `/boot/dietpi.txt`), so that they do not need to be set as sometimes otherwise described.
-
-    - Create new ***Fail2Ban filter*** (e.g. `/etc/fail2ban/filter.d/nextcloud.conf`):
+    1. Create new ***Fail2Ban filter***, e.g. `/etc/fail2ban/filter.d/nextcloud.conf`:
 
         ```ini
         # Fail2Ban filter for Nextcloud
@@ -176,31 +178,49 @@ Nextcloud gives you access to all your files wherever you are. Store your docume
         datepattern = ,?\s*"time"\s*:\s*"%%Y-%%m-%%d[T ]%%H:%%M:%%S(%%z)?"
         ```
 
-    - Create new ***Fail2Ban jail file*** `/etc/fail2ban/jail.d/nextcloud.local`:
+    1. Create new ***Fail2Ban jail file*** `/etc/fail2ban/jail.d/nextcloud.local`:
 
         ```ini
         [nextcloud]
-        backend = auto
         enabled = true
-        port = http,https
+        backend = auto
+        logpath = /mnt/dietpi_userdata/nextcloud_data/nextcloud.log
+        port = 80,443
         protocol = tcp
         filter = nextcloud
         maxretry = 5
         bantime = 600
-        logpath = /mnt/dietpi_userdata/nextcloud_data/nextcloud.log
         ```
 
-        Check whether the `logpath` is identical to the value in the Nextcloud configuration file (`config.php`see above).
+        Assure that the `logpath` matches the `'datadirectory'` value in the Nextcloud configuration file (`config.php` see above), or the `'logfile'` value if defined.
 
-        As not specified here, Fail2Ban uses properties like `maxretry`, `bantime`, etc. from `/etc/fail2ban/jail.conf` or `/etc/fail2ban/jail.local` (if present). Note the setting `backend = auto`. By default, `backend` is set to `systemd` in `/etc/fail2ban/jail.conf`. As a result, Fail2Ban ignores the `logpath` entry here in the jail `nextcloud.conf`, with the consequence, that Fail2Ban does not recognize an attack on Nextcloud (port 80, 443) even though attacks are listed in `/mnt/dietpi_userdata/nextcloud_data/nextcloud.log`.
+        Properties not defined here are taken from the `[DEFAULT]` block in `/etc/fail2ban/jail.conf` or `/etc/fail2ban/jail.local`, if present. Note the setting `backend = auto`: By default, `backend` is set to `systemd` in `/etc/fail2ban/jail.conf`. As a result, Fail2Ban would ignore the `logpath` entry here in the jail `nextcloud.conf`, with the consequence, that Fail2Ban does not recognize an attack on Nextcloud (port 80, 443) even though attacks are logged in `/mnt/dietpi_userdata/nextcloud_data/nextcloud.log`.
 
-    - Restart Fail2Ban: `systemctl restart fail2ban`.
-    - Test your settings by trying to sign in multiple times from a remote PC with a wrong user or password. After `maxretry` attempts your IP must be banned for `bantime` seconds (DietPi does not respond anymore) as the default action by Fail2Ban is `route`, specified in `/etc/fail2ban/action.d/route.conf`.
-    - Check the current status on your DietPi with `fail2ban-client status nextcloud`.
-    - See also:
-        - [Fail2Ban](../system_security/#fail2ban-protects-your-system-from-brute-force-attacks)
-        - <https://help.nextcloud.com/t/repeated-login-attempts-from-china/6510/11?u=michaing>
-        - <https://www.c-rieger.de/nextcloud-installationsanleitung/#c06>
+    1. Restart Fail2Ban:
+
+        ```sh
+        systemctl restart fail2ban
+        ```
+
+    1. Test your settings by trying to sign in multiple times from a remote PC with a wrong user or password. After `maxretry` attempts your IP should be banned for `bantime` seconds (DietPi does not respond anymore) as the default action by Fail2Ban is `route`, specified in `/etc/fail2ban/jail.conf` and defined in `/etc/fail2ban/action.d/route.conf`.
+
+    1. Check the current status on your DietPi:
+
+        ```sh
+        fail2ban-client status nextcloud
+        ```
+
+        IPs can be unbanned via:
+
+        ```sh
+        fail2ban-client unban 123.123.123.123
+        ```
+
+    See also:
+
+    - [Fail2Ban](../system_security/#fail2ban)
+    - <https://help.nextcloud.com/t/repeated-login-attempts-from-china/6510/11?u=michaing>
+    - <https://www.c-rieger.de/nextcloud-installationsanleitung/#c06>
 
 === "Update"
 

--- a/docs/software/system_security.md
+++ b/docs/software/system_security.md
@@ -80,10 +80,16 @@ An IP address is by default ban triggered after 3 failed SSH login attempts. Fai
     fail2ban-client status dropbear
     ```
 
+=== "Configuration"
+
+    Fail2Ban can handle several configuration options like e.g. general configuration and configurations for special programs on a config file base. The location of these config files is a directory structure within `/etc/fail2ban/` and its subdirectories.  
+    See the [Fail2Ban configuration documentation](https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Configuration) for further information.
+
 === "Enable support for additional programs"
 
     Fail2Ban supports brute-force protection for other software (e.g. Apache, ProFTPD etc). Pre-defined software filters can be found in the `/etc/fail2ban/filter.d/` directory.  
-    You can enable/disable these by adding additional `[software]` filter blocks to the `/etc/fail2ban/jail.conf` file, using the filters' file names without file extension. Properties not defined in a specific filter block, are taken from the `[DEFAULT]` block.
+    You can enable/disable these by adding additional `[software]` filter blocks to the `/etc/fail2ban/jail.conf` file, using the filters' file names without file extension. Properties not defined in a specific filter block, are taken from the `[DEFAULT]` block.  
+    See also the Fail2Ban configuration documentation for [Vsftpd](https://www.fail2ban.org/wiki/index.php/Vsftpd) and [ProFTPd](https://www.fail2ban.org/wiki/index.php/ProFTPd).
 
 ***
 

--- a/docs/software/system_security.md
+++ b/docs/software/system_security.md
@@ -89,7 +89,7 @@ An IP address is by default ban triggered after 3 failed SSH login attempts. Fai
 
     Fail2Ban supports brute-force protection for other software (e.g. Apache, ProFTPD etc). Pre-defined software filters can be found in the `/etc/fail2ban/filter.d/` directory.  
     You can enable/disable these by adding additional `[software]` filter blocks to the `/etc/fail2ban/jail.conf` file, using the filters' file names without file extension. Properties not defined in a specific filter block, are taken from the `[DEFAULT]` block.  
-    See also the Fail2Ban configuration documentation for [Vsftpd](https://www.fail2ban.org/wiki/index.php/Vsftpd) and [ProFTPd](https://www.fail2ban.org/wiki/index.php/ProFTPd).
+    See also the Fail2Ban configuration documentation for [vsftpd](https://www.fail2ban.org/wiki/index.php/Vsftpd) and [ProFTPD](https://www.fail2ban.org/wiki/index.php/ProFTPd).
 
 ***
 

--- a/docs/software/system_security.md
+++ b/docs/software/system_security.md
@@ -82,12 +82,12 @@ An IP address is by default ban triggered after 3 failed SSH login attempts. Fai
 
 === "Configuration"
 
-    Fail2Ban can handle several configuration options like e.g. general configuration and configurations for special programs on a config file base. The location of these config files is a directory structure within `/etc/fail2ban/` and its subdirectories.  
+    Fail2Ban can handle several configuration options like general configuration and configurations for special programs on a config file base. The location of these config files is a directory structure within `/etc/fail2ban/` and its subdirectories.  
     See the [Fail2Ban configuration documentation](https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Configuration) for further information.
 
 === "Enable support for additional programs"
 
-    Fail2Ban supports brute-force protection for other software (e.g. Apache, ProFTPD etc). Pre-defined software filters can be found in the `/etc/fail2ban/filter.d/` directory.  
+    Fail2Ban supports brute-force protection for other software, like Apache and ProFTPD. Pre-defined software filters can be found in the `/etc/fail2ban/filter.d/` directory.  
     You can enable/disable these by adding additional `[software]` filter blocks to the `/etc/fail2ban/jail.conf` file, using the filters' file names without file extension. Properties not defined in a specific filter block, are taken from the `[DEFAULT]` block.  
     See also the Fail2Ban configuration documentation for [vsftpd](https://www.fail2ban.org/wiki/index.php/Vsftpd) and [ProFTPD](https://www.fail2ban.org/wiki/index.php/ProFTPd).
 

--- a/docs/software/system_security.md
+++ b/docs/software/system_security.md
@@ -82,8 +82,8 @@ An IP address is by default ban triggered after 3 failed SSH login attempts. Fai
 
 === "Enable support for additional programs"
 
-    Fail2Ban supports brute-force protection for other software (e.g. Apache, ProFTPD etc).  
-    You can enable/disable these features by modifying the */etc/fail2ban/jail.conf* file, and setting `enable = true` under the *[software]* name.
+    Fail2Ban supports brute-force protection for other software (e.g. Apache, ProFTPD etc). Pre-defined software filters can be found in the `/etc/fail2ban/filter.d/` directory.  
+    You can enable/disable these by adding additional `[software]` filter blocks to the `/etc/fail2ban/jail.conf` file, using the filters' file names without file extension. Properties not defined in a specific filter block, are taken from the `[DEFAULT]` block.
 
 ***
 


### PR DESCRIPTION
The "Brute-force settings" app is installed now as part of Nextcloud core, which makes the app store link obsolete, but it is not enabled OOTB. However, the only thing it allows is to add whitelist entries, which has a too rare use case to mention, IMO. The internal brute-force protection does not hard block quickly, but adds an increasing amount of seconds as a timer to the login prompt. So this can be very safely tested without the risk of getting locked out for a long time. Users should hence not feel the need to enable this app, underlined by the fact that it is not enabled by default.

I took the chance to polish the two tabs a bit:
- making clear that Fail2Ban is an extension/further hardening of the internal brute-force protection
- using numbered setup steps
- adding a step to actually install Fail2Ban
- add, fix and rephrase further info: Some did not fit to our setup.