### PR TITLE
Exclude release notes links

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,4 +62,4 @@ jobs:
     - name: Run lychee to check README and HTML files
       if: always() && steps.lychee.outcome == 'success'
       # "429 Too Many Requests" on GitHub despite token
-      run: ./lychee -En --require-https --cache --exclude '^(root@192.168.1.20$|http://wiringpi.com/$|https://((adguard|nginx|shiori|nextcloud).box/$|twitter.com/DietPi_$|www.linux-kvm.org/$|pydio.com/|www.spigotmc.org/|help.realvnc.com/|help.roonlabs.com/|blynk.io/|play.google.com/store/apps/details))' -a 429 --github-token '${{ secrets.GITHUB_TOKEN }}' -b build README.md 'build/**/*.html'
+      run: ./lychee -En --require-https --cache --exclude '^(root@192.168.1.20$|http://wiringpi.com/$|https://((adguard|nginx|shiori|nextcloud).box/$|twitter.com/DietPi_$|www.linux-kvm.org/$|pydio.com/|www.spigotmc.org/|help.realvnc.com/|help.roonlabs.com/|blynk.io/|play.google.com/store/apps/details|github.com/MichaIng/DietPi-Docs/raw/dev/docs/releases/))' -a 429 --github-token '${{ secrets.GITHUB_TOKEN }}' -b build README.md 'build/**/*.html'


### PR DESCRIPTION
To avoid link check issues during new release note generation when new release notes file is not present under https://dietpi.com/docs/releases.

Or would a different action.yml be feasible to keep the link check for most other PRs?