### PR TITLE
Fix wrong HTTPS port

### DIFF
--- a/docs/dietpi_tools.md
+++ b/docs/dietpi_tools.md
@@ -161,7 +161,7 @@ When you execute the certificate installation it also installs it for your selec
 
 !!! info "Port forwarding on your router"
     To be accessible from the internet, typically your router needs a port forwarding configuration to route incoming HTTP and HTTPS accesses to your DietPi system.  
-    Although you only need a HTTPS protocol forwarding (typically port 433), you also need to forward the HTTP protocol (typically port 80) to your DietPi system, otherwise the certification renewal procedure will fail (due to the fact that the certification renewal procedure takes place several months later you may have forgotten this issue).
+    Although you only need a HTTPS protocol forwarding (typically port 443), you also need to forward the HTTP protocol (typically port 80) to your DietPi system, otherwise the certification renewal procedure will fail (due to the fact that the certification renewal procedure takes place several months later you may have forgotten this issue).
 
 ---
 


### PR DESCRIPTION
Port 443 is typically the HTTPS port, not port 433.