### PR TITLE
Changes to DietPi-Config docu

### DIFF
--- a/docs/dietpi_tools/system_configuration.md
+++ b/docs/dietpi_tools/system_configuration.md
@@ -10,81 +10,84 @@ dietpi-config
 
 ![DietPi-Config screenshot](../assets/images/dietpi-config.jpg){: width="643" height="335" loading="lazy"}
 
-### Display Options
+=== "Display Options"
 
-The display options are used to
+    The display options are used to
 
-- Set your screen resolution, or go headless to save additional resources.  
-- Control your GPU memory splits.  
-- Enable/disable the RPi camera.
+    - Set your screen resolution, or go headless to save additional resources.  
+    - Control your GPU memory splits.  
+    - Enable/disable the RPi camera.
 
-### Audio Options
+=== "Audio Options"
 
-The audio options are used to
+    The audio options are used to
 
-- Change sound cards with ease (e.g.: HiFiBerry / Odroid HiFi shield).
+    - Change sound cards with ease (e.g.: HiFiBerry / Odroid HiFi shield).
 
-### Performance Options
+=== "Performance Options"
 
-The performance options are used to
+    The performance options are used to
 
-- Overclock your system with a vast selection of overclocking profiles for your device.
-- Change the CPU governor and tweak your ARM temperature limits.
+    - Overclock your system with a vast selection of overclocking profiles for your device.
+    - Change the CPU governor and tweak your ARM temperature limits.
 
-### Advanced Options
+=== "Advanced Options"
 
-The advanced options are used to
+    The advanced options are used to
 
-- Configure swap file size
-- Configure time synchronization and real time clock source
-- Update device firmware
-- Toggle serial console
-- Toggle Bluetooth
+    - Configure swap file size
+    - Set APT cache handling
+    - Configure time synchronization and real time clock source
+    - Toggle serial console
+    - Toggle Bluetooth
 
-### Security Options
+=== "Security Options"
 
-The security options are used to
+    The security options are used to
 
-- Change password and hostname
+    - Change password and hostname
 
-### Language/Regional Options
+=== "Language/Regional Options"
 
-The language/regional options are used to
+    The language/regional options are used to
 
-- Set timezone, locale and keyboard options. Everything you will need to make it feel like home
+    - Set timezone, locale and keyboard options. Everything you will need to make it feel like home
 
-### Network Options: Adapters
+=== "Network Options: Adapters"
 
-The network options are used to
+    The network options are used to
 
-- Scan and connect to your WiFi router with ease
-- Change to a static IP address on your network
-- Configure your proxy settings
-- Test internet connection
-- Toggle IPv6 support
+    - Scan and connect to your WiFi router with ease
+    - Change to a static IP address on your network
+    - Configure your proxy settings
+    - Test internet connection
+    - Toggle IPv6 support
 
-### Network Options: Misc
+=== "Network Options: Misc"
 
-The miscellaneous network options options are used to
+    The miscellaneous network options options are used to
 
-- Select an **APT mirror** to connect to the Debian (or Raspbian) APT repository.
-- Select an **NTP mirror** to synchronise your system time.
-- Choose timeouts for network and URL connection tests.
-- **Network Drives** redirects you to the **DietPi-Drive_Manager** which allows you to mount Samba and NFS shares on your DietPi system.
-- **No-IP** is a [dynamic DNS](https://wikipedia.org/wiki/Dynamic_DNS) provider which allows you to access your home network/server with a static domain name. The client is required to inform No-IP of your current dynamic external IP on a regular basis.
+    - Select an **APT mirror** to connect to the Debian (or Raspbian) APT repository.
+    - Select an **NTP mirror** to synchronise your system time.
+    - Choose these options for the **network and URL connection tests**:
+        - Set Network test connection timeout and number of connection test tries.
+        - Set IPv4 and IPv6 addresses used for the connection test.
+        - Set the domain used for the domain name resolution test.
+    - **Network Drives** redirects you to the **DietPi-Drive_Manager** which allows you to mount Samba and NFS shares on your DietPi system.
+    - Select one of several **Dynamic DNS** ([**DDNS**](https://wikipedia.org/wiki/Dynamic_DNS)) providers which allows you to access your home network/server with a static domain name. The client is required to inform the DDNS of your current dynamic external IP on a regular basis.
 
-### AutoStart Options
+=== "AutoStart Options"
 
-The autostart options are used to
+    The autostart options are used to
 
-- Quickly and easily change what software runs after boot. Kodi, Desktop, console and many more
+    - Quickly and easily change what software runs after boot. Kodi, Desktop, console and many more
 
-### Tools
+=== "Tools"
 
-The tools options are used to
+    The tools options are used to
 
-- Perform CPU, RAM, filesystem and network **benchmarks**, optionally upload your results and review statistics at: <https://dietpi.com/survey/#benchmark>
-- Perform CPU/IO/RAM/DISK **stress tests** to test the stability of your system, e.g. after applying some overclocking.
+    - Perform CPU, RAM, filesystem and network **benchmarks**, optionally upload your results and review statistics at: <https://dietpi.com/survey/#benchmark>
+    - Perform CPU/IO/RAM/DISK **stress tests** to test the stability of your system, e.g. after applying some overclocking.
 
 ---
 


### PR DESCRIPTION
- Removed option of firmware update
- Added missing APT cache manage option
- Added new network connection test options
- Updated DDNS description
- Changed headings to tabs for DietPi-Config menu entries for better readability


See also issue #840.