### PR TITLE
Update cloud.md - Urbackup typo

### DIFF
--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -416,7 +416,7 @@ Clients are available for Windows, macOS, Linux and FreeBSD.
 
         ```sh
         mkdir /path/to/backup/storage
-        chmod -R urbackup:urbackup /path/to/backup/storage
+        chown -R urbackup:urbackup /path/to/backup/storage
         ```
 
 === "Download the client"


### PR DESCRIPTION
Changed the typo `chmod` to `chown` in the section about "Backup storage directory and access rights".

Reference: [https://dietpi.com/forum/t/external-ssd-with-urbackup/16303/30?u=jappe](https://dietpi.com/forum/t/external-ssd-with-urbackup/16303/30?u=jappe)