### PR TITLE
Fix Update cmd for motionEye cmd

### DIFF
--- a/docs/software/camera.md
+++ b/docs/software/camera.md
@@ -116,7 +116,7 @@ from any RPi camera, USB camera or an IP camera network stream.
     motionEye can be updated to the latest version via
 
     ```sh
-    sudo pip2 install -U motioneye
+    sudo pip3 install -U motioneye
     ```
 
 === "RPi camera module"

--- a/docs/software/camera.md
+++ b/docs/software/camera.md
@@ -116,7 +116,7 @@ from any RPi camera, USB camera or an IP camera network stream.
     motionEye can be updated to the latest version via
 
     ```sh
-    sudo pip3 install -U motioneye
+    sudo pip3 install -U --pre motioneye
     ```
 
 === "RPi camera module"


### PR DESCRIPTION
Either a typo or rather deprecated, you need to use pip3 to update motionEye.

Was tested on **DietPi v8.25.1 : 12:59 - Sat 12/30/23** freshly installed
`sudo: pip2: command not found`