### PR TITLE
Add YDNS link to dietpi-ddns section of software installation page.

### DIFF
--- a/docs/dietpi_tools/software_installation.md
+++ b/docs/dietpi_tools/software_installation.md
@@ -193,6 +193,7 @@ dietpi-ddns
 - Dynu: <https://www.dynu.com/>
 - FreeDNS: <https://freedns.afraid.org/>
 - OVH: <https://docs.ovh.com/gb/en/domains/hosting_dynhost/>
+- YDNS: <https://ydns.io/>
 - Alternatively you may use any other provider which has an API URL for updating your dynamic IP address.
 
 ### CLI


### PR DESCRIPTION
Just a small one-liner since I forgot to add this to the docs back when I added support a while back. Thanks!