### PR TITLE
Fix the command to change the Adguard Home password

### DIFF
--- a/docs/software/dns_servers.md
+++ b/docs/software/dns_servers.md
@@ -298,7 +298,7 @@ AdGuard Home is a DNS sinkhole with web interface that will block ads for any de
     If you forgot your login password for the AdGuard Home admin web page, you can set it with the following shell command on your AdGuard Home device.
 
     ```sh
-    G_CONFIG_INJECT 'password:[[:blank:]]' "  password: $(htpasswd -bnBC 10 '' "<your_new_password>" | tr -d ':\n' | sed 's/\$2y/\$2a/')" /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
+    G_CONFIG_INJECT 'password:[[:blank:]]' "    password: $(htpasswd -bnBC 10 '' "<your_new_password>" | tr -d ':\n' | sed 's/\$2y/\$2a/')" /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
     systemctl restart adguardhome
     ```
 


### PR DESCRIPTION
This PR fixes the command used to change the Adguard Home password.

It used to add 2 spaces before the line started which make it invalid, this PR just make it use 4 spaces.