### PR TITLE
Extend Home Assistant docs and fix Gitea links

### DIFF
--- a/docs/software/cloud.md
+++ b/docs/software/cloud.md
@@ -618,7 +618,7 @@ See also the [**Git**](programming.md#git) client which is available in `dietpi-
     - When you further try to login `maxretry` times, your IP should be banned for `bantime` seconds, so that neither the Gitea web interface, nor SSH or any other network application will respond to requests from your client. When Fail2Ban was installed via `dietpi-software`, by default `route`/`blackhole` blocking is used, so that `ip r` on the server should show a `blackhole` route for your client's IP.
     - See also:
         - [Fail2Ban](system_security.md#fail2ban)
-        - <https://docs.gitea.io/en-us/fail2ban-setup/>
+        - <https://docs.gitea.com/administration/fail2ban-setup>
 
 === "View logs"
 
@@ -640,9 +640,9 @@ See also the [**Git**](programming.md#git) client which is available in `dietpi-
 
 ***
 
-Official website: <https://gitea.io/>  
-Official documentation: <https://docs.gitea.io/>  
-Official forum: <https://discourse.gitea.io/>  
+Official website: <https://about.gitea.com/>  
+Official documentation: <https://docs.gitea.com/>  
+Official forum: <https://forum.gitea.com/>  
 Source code: <https://github.com/go-gitea/gitea>  
 License: [MIT](https://github.com/go-gitea/gitea/blob/main/LICENSE)
 

--- a/docs/software/home_automation.md
+++ b/docs/software/home_automation.md
@@ -39,7 +39,7 @@ Home Assistant is an open-source home automation platform running on Python 3. T
 
     !!! info "Automate install of additional dependencies"
         Some integrations may require additional APT and/or Python dependencies. The latter are usually installed ondemand by the Home Assistant core, when installing or accessing the integration, but APT packages need to be installed manually.  
-	This can be automated with two `dietpi.txt` settings: `SOFTWARE_HOMEASSISTANT_APT_DEPS` and `SOFTWARE_HOMEASSISTANT_PIP_DEPS`
+        This can be automated with two `dietpi.txt` settings: `SOFTWARE_HOMEASSISTANT_APT_DEPS` and `SOFTWARE_HOMEASSISTANT_PIP_DEPS`
 
     !!! warning "Long installation duration"
         The install process on slower SBC models can take a up to 2 hours, hence take a coffee, find some other activity and check back once in a while. It will show "Installing Python-3.x.x..." a very long time.  

--- a/docs/software/home_automation.md
+++ b/docs/software/home_automation.md
@@ -37,8 +37,12 @@ Home Assistant is an open-source home automation platform running on Python 3. T
 
 === "Initial install and access"
 
-    !!! info "Long installation duration"
-        The install process on slower SBC models can take a very long time, up to 2 hours, hence take a coffee, find some other activity and check back once in a while. It will show Installing Python-3.x.x... a very long time.  
+    !!! info "Automate install of additional dependencies"
+        Some integrations may require additional APT and/or Python dependencies. The latter are usually installed ondemand by the Home Assistant core, when installing or accessing the integration, but APT packages need to be installed manually.  
+	This can be automated with two `dietpi.txt` settings: `SOFTWARE_HOMEASSISTANT_APT_DEPS` and `SOFTWARE_HOMEASSISTANT_PIP_DEPS`
+
+    !!! warning "Long installation duration"
+        The install process on slower SBC models can take a up to 2 hours, hence take a coffee, find some other activity and check back once in a while. It will show "Installing Python-3.x.x..." a very long time.  
         If you want to see processing details, run `htop` on a dedicated terminal or SSH session to watch Python build process live.
 
     After `dietpi-software` has finished and the service starts the first time, please go through the following steps manually:
@@ -96,7 +100,8 @@ Home Assistant is an open-source home automation platform running on Python 3. T
     /home/homeassistant/homeassistant-update.sh
     ```
 
-    To update as well the whole `pyenv` Python version, reinstall Home Assistant:
+    Home Assistant updates may drop support for old Python versions. The release notes would inform about this: <https://github.com/home-assistant/core/releases>  
+    To update the `pyenv` Python version along with Home Assistant, reinstall it. Since Python dependencies need to be reinstalled, the first service start, and accessing certain integrations for the first time, may again take a while:
 
     ```sh
     dietpi-software reinstall 157
@@ -104,7 +109,10 @@ Home Assistant is an open-source home automation platform running on Python 3. T
 
 ***
 
-Official documentation: <https://home-assistant.io/docs>
+Official website: <https://www.home-assistant.io/>  
+Official documentation: <https://home-assistant.io/docs>  
+Source code: <https://github.com/home-assistant/core>  
+License: [Apache-2.0](https://github.com/home-assistant/core/blob/dev/LICENSE.md)
 
 ## Domoticz
 

--- a/docs/software/webserver_stack.md
+++ b/docs/software/webserver_stack.md
@@ -102,7 +102,7 @@ DietPi offers an **one-click-installation** of the following web development sta
     It is an open source RDBMS (relational data base management system). It is application compatible to MySQL, i.e. it can be used as a *drop in* replacement for MySQL. It has more features, fewer bugs, and a better performance compared to MySQL.[^2]
 
     **[SQLite](databases.md#sqlite)**  
-    It is an RDBMS, also compatible to MySQL. It offers a broader language support (i.e. more bindings to programming languages) compared to [MariaDB](databases.md#mariadb). [SQLite](databases.md#sqlite) has a very small footprint. As drawbacks, it has no multi user capabilities and a couple of SQL features are missing.[^3]
+    It is an RDBMS, also compatible to MySQL. It offers a broader language support (i.e. more bindings to programming languages) compared to [MariaDB](databases.md#mariadb). [SQLite](databases.md#sqlite) has a very small footprint. As drawbacks, it has no memory caching, no multi user capabilities and a couple of SQL features are missing.[^3]
 
 ***
 


### PR DESCRIPTION
The MariaDB article is currently not reachable: https://www2.computerworld.com.au/article/457551/dead_database_walking_mysql_creator_why_future_belongs_mariadb/

Using `www` instead of `www2` works, but the article then cannot be found. Probably it was been removed, need to check back in some days, when the 503 on `www2` is gone.