### PR TITLE
Change link to log system

### DIFF
--- a/docs/software/log_system.md
+++ b/docs/software/log_system.md
@@ -20,7 +20,7 @@ The *Log System* can be changed at any time by running `dietpi-software` and sel
 --8<---------- "snippet-includes/DietPi-Software_infoblock.md"
 
 ???+ seealso "Examining the logging information"
-    A description of the basic log information display and filter option is given in the [HowTo section of the DietPi documentation](../usage.md).
+    A description of the basic log information display and filter option is given in the [HowTo section of the DietPi documentation](../dietpi_tools/software_installation.md#log-system-selection).
 
 [Return to the **Optimised Software list**](../software.md)
 


### PR DESCRIPTION
The section for the log system choice changed with (https://github.com/MichaIng/DietPi-Docs/pull/1133).
One link in `log-system.md` was still pointing to "Usage / Hints" section.
It points now to the correct place `../dietpi_tools/software_installation.md#log-system-selection`